### PR TITLE
Fix hostname option name in conf example

### DIFF
--- a/etc/smartdns/smartdns.conf
+++ b/etc/smartdns/smartdns.conf
@@ -131,7 +131,7 @@ log-level info
 # server-tls [IP]:[PORT] [-blacklist-ip] [-whitelist-ip] [-spki-pin [sha256-pin]] [-group [group] ...] [-exclude-default-group]
 #   -spki-pin: TLS spki pin to verify.
 #   -tls-host-check: cert hostname to verify.
-#   -hostname: TLS sni hostname.
+#   -host-name: TLS sni hostname.
 # Get SPKI with this command:
 #    echo | openssl s_client -connect '[ip]:853' | openssl x509 -pubkey -noout | openssl pkey -pubin -outform der | openssl dgst -sha256 -binary | openssl enc -base64
 # default port is 853
@@ -142,7 +142,7 @@ log-level info
 # server-https https://[host]:[port]/path [-blacklist-ip] [-whitelist-ip] [-spki-pin [sha256-pin]] [-group [group] ...] [-exclude-default-group]
 #   -spki-pin: TLS spki pin to verify.
 #   -tls-host-check: cert hostname to verify.
-#   -hostname: TLS sni hostname.
+#   -host-name: TLS sni hostname.
 #   -http-host: http host.
 # default port is 443
 # server-https https://cloudflare-dns.com/dns-query


### PR DESCRIPTION
The hostname option is actually `-host-name` as in the code and README. Setting `-hostname` doesn't work.