### PR TITLE
fix dnsmasq illegal repeated keyword error

### DIFF
--- a/package/optware/S50smartdns
+++ b/package/optware/S50smartdns
@@ -162,15 +162,17 @@ set_dnsmasq_conf()
 	fi
 
 	grep "^port *=0" "$CONF_FILE" > /dev/null 2>&1
-	if [ $? -ne 0 ]; then
+	if [ $? -ne 0 ] && [ ! "$ADDED_PORT" ]; then
 		sed -i "/^port *=/d" "$CONF_FILE"
 		echo "port=0" >> "$CONF_FILE"
 		RESTART_DNSMASQ=1
+		ADDED_PORT="true"
 	fi
 }
 
 set_dnsmasq()
 {
+	ADDED_PORT=""
 	local RESTART_DNSMASQ=0
 
 	for conf in $DNSMASQ_CONF


### PR DESCRIPTION
there are two dnsmasq.conf files in my router  

- /etc/dnsmasq.conf  
- /etc/storage/dnsmasq/dnsmasq.conf  

and the /etc/dnsmasq.conf file it include the second file with option:  
`conf-file=/etc/storage/dnsmasq/dnsmasq.conf`  

`S50smartdns->set_dnsmasq_conf` add option `port=0` into both files  
it cause dnsmasq start error:  

> "dnsmasq: illegal repeated keyword at line 36 of /etc/dnsmasq.conf"