### PR TITLE
Support docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+ FROM debian:buster-slim
+
+ RUN apt update && \
+     apt install -y git make gcc libssl-dev && \
+     git clone https://github.com/pymumu/smartdns.git --depth 1 && \
+     cd smartdns && \
+     sh ./package/build-pkg.sh --platform debian --arch amd64 && \
+     dpkg -i package/*.deb && \
+     cd / && \
+     rm -rf smartdns/ && \
+     apt autoremove -y git make gcc libssl-dev
+
+ EXPOSE 53/udp
+ VOLUME "/etc/smartdns/"
+
+ CMD ["/usr/sbin/smartdns", "-f"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,13 @@
      apt install -y git make gcc libssl-dev && \
      git clone https://github.com/pymumu/smartdns.git --depth 1 && \
      cd smartdns && \
-     sh ./package/build-pkg.sh --platform debian --arch amd64 && \
+     sh ./package/build-pkg.sh --platform debian --arch `dpkg --print-architecture` && \
      dpkg -i package/*.deb && \
      cd / && \
      rm -rf smartdns/ && \
-     apt autoremove -y git make gcc libssl-dev
+     apt autoremove -y git make gcc libssl-dev && \
+     apt clean && \
+     rm -rf /var/lib/apt/lists/*
 
  EXPOSE 53/udp
  VOLUME "/etc/smartdns/"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,19 @@
- FROM debian:buster-slim
+FROM debian:buster-slim
 
- RUN apt update && \
-     apt install -y git make gcc libssl-dev && \
-     git clone https://github.com/pymumu/smartdns.git --depth 1 && \
-     cd smartdns && \
-     sh ./package/build-pkg.sh --platform debian --arch `dpkg --print-architecture` && \
-     dpkg -i package/*.deb && \
-     cd / && \
-     rm -rf smartdns/ && \
-     apt autoremove -y git make gcc libssl-dev && \
-     apt clean && \
-     rm -rf /var/lib/apt/lists/*
+RUN apt update && \
+apt install -y git make gcc libssl-dev && \
+    git clone https://github.com/pymumu/smartdns.git && \
+    cd smartdns && \
+    git checkout $(git describe --tags) && \
+    sh ./package/build-pkg.sh --platform debian --arch `dpkg --print-architecture` && \
+    dpkg -i package/*.deb && \
+    cd / && \
+    rm -rf smartdns/ && \
+    apt purge -y --autoremove git make gcc libssl-dev && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/*
 
- EXPOSE 53/udp
- VOLUME "/etc/smartdns/"
+EXPOSE 53/udp
+VOLUME "/etc/smartdns/"
 
- CMD ["/usr/sbin/smartdns", "-f"]
+CMD /usr/sbin/smartdns && tail -f /var/log/smartdns.log 2>/dev/null


### PR DESCRIPTION
### Run as docker:
```shell
docker build -t smartdns/smartdns .
docker run -d --name smartdns -p 53:53/udp -v /path/to/smartdns/config/:/etc/smartdns/ --restart=always smartdns/smartdns
```
> Dockerfile中使用**dpkg --print-architecture**获取当前的arch，基础镜像支持的arch可通过**dpkg-architecture --list**获取。
> 由于设备的限制，目前只测试并通过**amd64**架构。