### PR TITLE
Move TimeoutStopSec to [Service]

### DIFF
--- a/systemd/smartdns.service.in
+++ b/systemd/smartdns.service.in
@@ -3,7 +3,6 @@ Description=smartdns server
 After=network.target 
 StartLimitBurst=0
 StartLimitIntervalSec=60
-TimeoutStopSec=5
 
 [Service]
 Type=forking
@@ -13,6 +12,7 @@ ExecStart=@SBINDIR@/smartdns -p @RUNSTATEDIR@/smartdns.pid $SMART_DNS_OPTS
 KillMode=process
 Restart=always
 RestartSec=2
+TimeoutStopSec=5
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
It belongs here. Setting it in [Unit] produces the following warning:

```
systemd[1]: /usr/lib/systemd/system/smartdns.service:6: Unknown key name 'TimeoutStopSec' in section 'Unit', ignoring.
```