### PR TITLE
Update luci-app-smartdns.json

### DIFF
--- a/package/luci/files/root/usr/share/luci/menu.d/luci-app-smartdns.json
+++ b/package/luci/files/root/usr/share/luci/menu.d/luci-app-smartdns.json
@@ -6,6 +6,7 @@
 			"path": "smartdns/smartdns"
 		},
 		"depends": {
+			"acl": [ "luci-app-smartdns" ],
 			"uci": { "smartdns": true }
 		}
 	}


### PR DESCRIPTION
With this small fix, the menu entry for smartdns is not shown anymore on the login page of openwrt.