### PR TITLE
Update ReadMe.md

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -17,7 +17,7 @@ SmartDNS是一个运行在本地的DNS服务器，SmartDNS接受本地客户端�
 1. [使用](#使用)  
     1. [下载配套安装包](#下载配套安装包)
     1. [标准Linux系统安装](#标准linux系统安装树莓派x86_64系统)
-    1. [openwrt/LEDE](#openwrtlede)
+    1. [openwrt/LEDE](#openwrt)
     1. [华硕路由器原生固件/梅林固件](#华硕路由器原生固件梅林固件)
     1. [optware/entware](#optwareentware)
     1. [Windows 10 WSL安装/WSL ubuntu](#windows-10-wsl安装wsl-ubuntu)


### PR DESCRIPTION
点击第 20 行 的链接无法正常跳到对应 223 行的 openwrt 
原来的 https://github.com/pymumu/smartdns#openwrtlede ,对应的应该是 https://github.com/pymumu/smartdns#openwrt 。
修改后可以正常跳转。