### PR TITLE
fix `x86_64-linux-gnu-gcc` compile error

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -28,6 +28,7 @@
 #include <fcntl.h>
 #include <inttypes.h>
 #include <linux/capability.h>
+#include <linux/limits.h>
 #include <linux/netlink.h>
 #include <netinet/tcp.h>
 #include <openssl/crypto.h>


### PR DESCRIPTION
```
util.c: In function ‘parse_uri’:
util.c:389:17: error: ‘PATH_MAX’ undeclared (first use in this function); did you mean ‘AF_MAX’?
  389 |  char host_name[PATH_MAX];
      |                 ^~~~~~~~
      |                 AF_MAX
util.c:389:17: note: each undeclared identifier is reported only once for each function it appears in
```