### PR TITLE
Add user configuration

### DIFF
--- a/package/openwrt/files/etc/init.d/smartdns
+++ b/package/openwrt/files/etc/init.d/smartdns
@@ -32,6 +32,9 @@ SMARTDNS_CONF_TMP="${SMARTDNS_CONF}.tmp"
 COREDUMP="0"
 RESPAWN="1"
 
+# USER="smartdns"         # default is root user.
+# GROUP="smartdns"
+
 set_forward_dnsmasq()
 {
 	local PORT="$1"
@@ -362,6 +365,8 @@ load_service()
 	} >> $SMARTDNS_CONF_TMP
 	mv $SMARTDNS_CONF_TMP $SMARTDNS_CONF
 
+        touch $SERVICE_PID_FILE 
+        [ -z "$USER" ] || chown -R $USER:$GROUP $SERVICE_PID_FILE
 	procd_open_instance "smartdns"
 	[ "$COREDUMP" = "1" ] && {
 		args="$args -S"
@@ -370,7 +375,7 @@ load_service()
 
 	get_tz
 	[ -z "$SET_TZ" ] || procd_set_param env TZ="$SET_TZ"
-
+        [ -z "$USER" ] || procd_set_param user $USER
 	procd_set_param command /usr/sbin/smartdns -f -c $SMARTDNS_CONF $args
 	[ "$RESPAWN" = "1" ] &&	procd_set_param respawn ${respawn_threshold:-3600} ${respawn_timeout:-5} ${respawn_retry:-5}
 	procd_set_param file "$SMARTDNS_CONF"


### PR DESCRIPTION
Add smardns can run `smartdns` user configuration. But I don't know why dnsmasq run with user `dnsmasq` can listen on 53 port