### PR TITLE
fix openssl1.1 without 0.9.8 api compile error

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -737,7 +737,11 @@ void SSL_CRYPTO_thread_setup(void)
 		pthread_mutex_init(&(lock_cs[i]), NULL);
 	}
 
+#if OPENSSL_API_COMPAT < 0x10000000
 	CRYPTO_set_id_callback(_pthreads_thread_id);
+#else
+	CRYPTO_THREADID_set_callback(_pthreads_thread_id);
+#endif
 	CRYPTO_set_locking_callback(_pthreads_locking_callback);
 }
 


### PR DESCRIPTION
when `./Configure --api=1.0.0`, we should not use CRYPTO_set_id_callback().