### PR TITLE
bugfix: netlink: 'smartdns': attribute type 6 has an invalid length

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -518,6 +518,7 @@ static int _ipset_operate(const char *ipsetname, const unsigned char addr[], int
 	ssize_t rc;
 	int af = 0;
 	static const struct sockaddr_nl snl = {.nl_family = AF_NETLINK};
+	uint32_t expire;
 
 	if (addr_len != IPV4_ADDR_LEN && addr_len != IPV6_ADDR_LEN) {
 		errno = EINVAL;
@@ -572,8 +573,8 @@ static int _ipset_operate(const char *ipsetname, const unsigned char addr[], int
 	nested[1]->len = (void *)buffer + NETLINK_ALIGN(netlink_head->nlmsg_len) - (void *)nested[1];
 
 	if (timeout > 0 && _ipset_support_timeout(ipsetname) == 0) {
-		timeout = htonl(timeout);
-		_ipset_add_attr(netlink_head, IPSET_ATTR_TIMEOUT | NLA_F_NET_BYTEORDER, sizeof(timeout), &timeout);
+		expire = htonl(timeout);
+		_ipset_add_attr(netlink_head, IPSET_ATTR_TIMEOUT | NLA_F_NET_BYTEORDER, sizeof(expire), &expire);
 	}
 
 	nested[0]->len = (void *)buffer + NETLINK_ALIGN(netlink_head->nlmsg_len) - (void *)nested[0];


### PR DESCRIPTION
Add resolved IP into ipsets failed, and the kernel **5.10.x** reports errors:
```
[19945.517047] netlink: 'smartdns': attribute type 6 has an invalid length.
```

Ref. https://github.com/torvalds/linux/blob/master/include/linux/netfilter/ipset/ip_set.h#L268