### PR TITLE
Different version scheme results in Debian package overwrite

### DIFF
--- a/package/debian/DEBIAN/changelog
+++ b/package/debian/DEBIAN/changelog
@@ -1,4 +1,4 @@
-smartdns (1.2018.7.9) stable; urgency=low
+smartdns (1:1.2022.04.05) stable; urgency=low
 
   * Initial build
 


### PR DESCRIPTION
Closes: https://github.com/pymumu/smartdns/issues/748