### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,18 @@
 FROM ubuntu:latest as smartdns-builder
 
+LABEL previous-stage=smartdns
 COPY . /smartdns/
 RUN  apt update && \
      apt install -y make gcc libssl-dev && \
+     chmod -R 0755 smartdns && \
      cd smartdns && \
      sh ./package/build-pkg.sh --platform debian --arch `dpkg --print-architecture`
 
 FROM ubuntu:latest
 COPY --from=smartdns-builder /smartdns/package/*.deb /opt/
+COPY --from=smartdns-builder /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1 /usr/lib/x86_64-linux-gnu/
+COPY --from=smartdns-builder /usr/lib/x86_64-linux-gnu/libssl.so.1.1 /usr/lib/x86_64-linux-gnu/
+COPY --from=smartdns-builder /usr/lib/x86_64-linux-gnu/engines-1.1/* /usr/lib/x86_64-linux-gnu/engines-1.1/
 RUN dpkg -i /opt/*.deb && \
     rm /opt/*deb -fr
 


### PR DESCRIPTION
1. 增加中间层镜像label，在build后可以方便的使用命令 ```docker rmi `docker images --filter label=previous-stage=smartdns -q` ```移除中间层镜像
3. 增加libssl支持（否则报找不到libssl.so，不启动
4. 修改工作目录权限，dpkg-deb要求权限必须为755或775