### PR TITLE
优化识别wsl的方式，解决部分wsl无法识别的问题

### DIFF
--- a/package/linux/install
+++ b/package/linux/install
@@ -187,7 +187,7 @@ init_dir()
 	which systemctl >/dev/null 2>&1
 	ISSYSTEMD="$?"
 	# Running under WSL (Windows Subsystem for Linux)?
-	cat /proc/version | grep Microsoft >/dev/null 2>&1; 
+	cat /proc/version | grep -E '[Mm]icrosoft' >/dev/null 2>&1; 
 	if [ $? -eq 0 ]; then
 		ISSYSTEMD=1
 		ISWSL=0


### PR DESCRIPTION
部分linux系统的/proc/version里的‘Microsoft’是小写‘m’，导致无法识别出来，比如我的就是`Linux version 5.10.16.3-microsoft-standard-WSL2 (oe-user@oe-host)...`，解决方式目前有以下几种：
1、 `grep -i Microsoft`忽略大小写
2、 `grep -E '[Mm]icrosoft'`正则匹配
通过正则可能更方便在（假如）后续微软乱搞起别的名字时添加新规则
![image](https://user-images.githubusercontent.com/25813490/183350690-a52dc31c-315c-4ed0-a526-910889357d80.png)

