### PR TITLE
luci-compat: fix dnsmasq redirect status

### DIFF
--- a/package/luci-compat/files/luci/controller/smartdns.lua
+++ b/package/luci-compat/files/luci/controller/smartdns.lua
@@ -38,7 +38,7 @@ end
 function act_status()
 	local e={}
 	local ipv6_server;
-	local dnsmasq_server = luci.sys.exec("uci get dhcp.@dnsmasq[0].server")
+	local dnsmasq_server = smartdns.get_config_option("dhcp", "dnsmasq", "server", {nil})[1]
 	local auto_set_dnsmasq = smartdns.get_config_option("smartdns", "smartdns", "auto_set_dnsmasq", nil);
 	
 	e.auto_set_dnsmasq = auto_set_dnsmasq
@@ -47,7 +47,7 @@ function act_status()
 	if e.local_port ~= nil and e.local_port ~= "53" and auto_set_dnsmasq ~= nil and auto_set_dnsmasq == "1" then
 		local str;
 		str = "127.0.0.1#" .. e.local_port 
-		if string.sub(dnsmasq_server,1,string.len(str)) ~= str then 
+		if dnsmasq_server ~= str then
 			e.dnsmasq_redirect_failure = 1
 		end
 	end


### PR DESCRIPTION
`if string.sub(dnsmasq_server,1,string.len(str)) ~= str then` is wrong. For example, dnsmasq_server="127.0.0.1#1234" and str="127.0.0.1#123", then the  dnsmasq redirect status is incorrect.