### PR TITLE
fix Ubuntu service name

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -204,7 +204,7 @@ entware|ipkg update<br>ipkg install smartdns|软件源路径：https://bin.entwa
     ```
 
     **对于Ubuntu系统：**
-    * `systemd-resolve`会占用TCP53和UDP53端口。你需要手动解决端口占用问题或者修改smartdns监听端口
+    * `systemd-resolved`会占用TCP53和UDP53端口。你需要手动解决端口占用问题或者修改smartdns监听端口
 
     * 日志文件在`/var/log/smartdns/smartdns.log`
 2. 修改配置

--- a/ReadMe_en.md
+++ b/ReadMe_en.md
@@ -196,7 +196,7 @@ https://github.com/pymumu/smartdns/releases
     ./install -i
     ```
     **For Ubuntu system:**
-    * `systemd-resolve` occupies TCP53 and UDP53 ports. You need to manually resolve the port occupancy problem or modify the SmartDNS listening port
+    * `systemd-resolved` occupies TCP53 and UDP53 ports. You need to manually resolve the port occupancy problem or modify the SmartDNS listening port
 
     * Log files in `/var/log/smartdns/smartdns.log`
 


### PR DESCRIPTION
参考 [Ubuntu man page](https://manpages.ubuntu.com/manpages/xenial/man8/systemd-resolved.service.8.html)。此外 Fedora、Archlinux 也采用 systemd-resolved 作为 dns 服务。