### PR TITLE
smartdns.conf: fix default value of dualstack-ip-selection

### DIFF
--- a/etc/smartdns/smartdns.conf
+++ b/etc/smartdns/smartdns.conf
@@ -121,7 +121,7 @@ force-qtype-SOA 65
 # dualstack-ip-selection-threshold [num] (0~1000)
 # dualstack-ip-allow-force-AAAA [yes|no]
 # dualstack-ip-selection [yes|no]
-# dualstack-ip-selection no
+# dualstack-ip-selection yes
 
 # edns client subnet
 # edns-client-subnet [ip/subnet]


### PR DESCRIPTION
In https://github.com/pymumu/smartdns/blob/0340d272c3e7a618a5b605d7daf8ab07901ab63a/src/dns_conf.c#L139 the default value of dns_conf_dualstack_ip_selection is set to 1, which is "yes".

This means dualstack-ip-selection is enabled by default, and the commented out "no" is misleading here.