### PR TITLE
tlog: fix declaration of `tlog_set_permission`

### DIFF
--- a/src/tlog.c
+++ b/src/tlog.c
@@ -330,7 +330,7 @@ void tlog_logcount(struct tlog_log *log, int count)
     log->logcount = count;
 }
 
-void tlog_set_permission(struct tlog_log *log, unsigned int file, unsigned int archive)
+void tlog_set_permission(struct tlog_log *log, mode_t file, mode_t archive)
 {
     log->file_perm = file;
     log->archive_perm = archive;


### PR DESCRIPTION
On some systems (like 32-bit Android), `mode_t` is not a typedef of `unsigned int`.
