### PR TITLE
Add `nss-lookup.target` as dependency for service

### DIFF
--- a/systemd/smartdns.service.in
+++ b/systemd/smartdns.service.in
@@ -1,6 +1,8 @@
 [Unit]
 Description=SmartDNS Server
-After=network.target 
+After=network.target
+Before=network-online.target nss-lookup.target
+Wants=nss-lookup.target
 StartLimitBurst=0
 StartLimitIntervalSec=60
 
@@ -8,7 +10,7 @@ StartLimitIntervalSec=60
 Type=forking
 PIDFile=@RUNSTATEDIR@/smartdns.pid
 EnvironmentFile=@SYSCONFDIR@/default/smartdns
-ExecStart=@SBINDIR@/smartdns -p @RUNSTATEDIR@/smartdns.pid $SMART_DNS_OPTS 
+ExecStart=@SBINDIR@/smartdns -p @RUNSTATEDIR@/smartdns.pid $SMART_DNS_OPTS
 Restart=always
 RestartSec=2
 TimeoutStopSec=15


### PR DESCRIPTION
在smartdns之后调用`nss-lookup.target`，以便smartdns在作为系统dns服务器的系统上能够在依赖dns查询的服务之前启动，如nginx。

参考[5.2Running services after the network is up](https://wiki.archlinux.org/title/Systemd#Running_services_after_the_network_is_up)以及https://gitlab.archlinux.org/archlinux/packaging/packages/dnsmasq/-/blob/main/dnsmasq.service