### PR TITLE
add domain rule "root or sub"

### DIFF
--- a/src/dns_conf.c
+++ b/src/dns_conf.c
@@ -917,6 +917,10 @@ static int _config_domain_rule_add(const char *domain, enum domain_rule type, vo
 		len--;
 		if (domain[1] == '.') {
 			sub_rule_only = 1;
+		} else if ((domain[1] == '-') && (domain[2] == '.')) {
+			len--;
+			sub_rule_only = 1;
+			root_rule_only = 1;
 		}
 	} else if (domain[0] == '-') {
 		/* root match only */

--- a/src/dns_server.c
+++ b/src/dns_server.c
@@ -4046,14 +4046,16 @@ static int _dns_server_get_rules(unsigned char *key, uint32_t key_len, int is_su
 		return 0;
 	}
 
-	/* only subkey rule */
-	if (domain_rule->sub_rule_only == 1 && is_subkey == 0) {
-		return 0;
-	}
+	if (domain_rule->sub_rule_only != domain_rule->root_rule_only) {
+		/* only subkey rule */
+		if (domain_rule->sub_rule_only == 1 && is_subkey == 0) {
+			return 0;
+		}
 
-	/* only root key rule */
-	if (domain_rule->root_rule_only == 1 && is_subkey == 1) {
-		return 0;
+		/* only root key rule */
+		if (domain_rule->root_rule_only == 1 && is_subkey == 1) {
+			return 0;
+		}
 	}
 
 	for (i = 0; i < DOMAIN_RULE_MAX; i++) {


### PR DESCRIPTION
there is a bug which domain "example.com" cannot match rule "*-.example.com",
and fix it with this pull