### PR TITLE
test-speed-check: increase timeout limit for lowend dev

### DIFF
--- a/test/cases/test-speed-check.cc
+++ b/test/cases/test-speed-check.cc
@@ -99,7 +99,7 @@ cache-persist no)""");
 	std::cout << client.GetResult() << std::endl;
 	ASSERT_EQ(client.GetAnswerNum(), 2);
 	EXPECT_EQ(client.GetStatus(), "NOERROR");
-	EXPECT_LT(client.GetQueryTime(), 20);
+	EXPECT_LT(client.GetQueryTime(), 40);
 	EXPECT_EQ(client.GetAnswer()[0].GetName(), "b.com");
 	EXPECT_EQ(client.GetAnswer()[0].GetTTL(), 600);
 
@@ -107,7 +107,7 @@ cache-persist no)""");
 	std::cout << client.GetResult() << std::endl;
 	ASSERT_EQ(client.GetAnswerNum(), 2);
 	EXPECT_EQ(client.GetStatus(), "NOERROR");
-	EXPECT_LT(client.GetQueryTime(), 20);
+	EXPECT_LT(client.GetQueryTime(), 40);
 	EXPECT_EQ(client.GetAnswer()[0].GetName(), "a.com");
 	EXPECT_EQ(client.GetAnswer()[0].GetTTL(), 600);
 	EXPECT_EQ(client.GetAnswer()[0].GetData(), "1.2.3.4");


### PR DESCRIPTION
Increase timeout limit for lowend dev, especially for riscv64, which would get a fail on test-speed-check(none).