### PR TITLE
改正openwrt上bind網路卡的行為

### DIFF
--- a/package/openwrt/files/etc/init.d/smartdns
+++ b/package/openwrt/files/etc/init.d/smartdns
@@ -616,6 +616,79 @@ load_second_server()
 	[ "$seconddns_tcp_server" = "1" ] && conf_append_bind "bind-tcp" "$seconddns_port" "$device" "$ipv6_server" "$ARGS"
 }
 
+load_second_service()
+{
+        local section="$1"
+        local server_flags=""
+        local ADDR=""
+        local device=""
+
+        config_get_bool enabled "$section" "enabled" "0"
+        [ "$enabled" = "0" ] && return
+
+        config_get port "$section" "port" "6553"
+
+        config_get_bool no_speed_check "$section" "no_speed_check" "0"
+        [ "$no_speed_check" = "1" ] && server_flags="$server_flags -no-speed-check"
+
+        config_get server_group "$section" "server_group" ""
+        [ -z "$server_group" ] || server_flags="$server_flags -group $server_group"
+
+        config_get_bool no_rule_addr "$section" "no_rule_addr" "0"
+        [ "$no_rule_addr" = "1" ] && server_flags="$server_flags -no-rule-addr"
+
+        config_get_bool no_rule_nameserver "$section" "no_rule_nameserver" "0"
+        [ "$no_rule_nameserver" = "1" ] && server_flags="$server_flags -no-rule-nameserver"
+
+        config_get_bool no_rule_ipset "$section" "no_rule_ipset" "0"
+        [ "$no_rule_ipset" = "1" ] && server_flags="$server_flags -no-rule-ipset"
+
+        config_get_bool no_rule_soa "$section" "no_rule_soa" "0"
+        [ "$no_rule_soa" = "1" ] && server_flags="$server_flags -no-rule-soa"
+
+        config_get_bool no_dualstack_selection "$section" "no_dualstack_selection" "0"
+        [ "$no_dualstack_selection" = "1" ] && server_flags="$server_flags -no-dualstack-selection"
+
+        config_get_bool no_cache "$section" "no_cache" "0"
+        [ "$no_cache" = "1" ] && server_flags="$server_flags -no-cache"
+
+        config_get_bool force_aaaa_soa "$section" "force_aaaa_soa" "0"
+        [ "$force_aaaa_soa" = "1" ] && server_flags="$server_flags -force-aaaa-soa"
+
+        config_get_bool force_https_soa "$section" "force_https_soa" "0"
+        [ "$force_https_soa" = "1" ] && server_flags="$server_flags -force-https-soa"
+
+        config_get_bool no_ip_alias "$section" "no_ip_alias" "0"
+        [ "$no_ip_alias" = "1" ] && server_flags="$server_flags -no-ip-alias"
+
+        config_get ipset_name "$section" "ipset_name" ""
+        [ -z "$ipset_name" ] || server_flags="$server_flags -ipset $ipset_name"
+
+        config_get nftset_name "$section" "nftset_name" ""
+        [ -z "$nftset_name" ] || server_flags="$server_flags -nftset $nftset_name"
+
+        config_get_bool bind_device "$section" "bind_device" "0"
+        config_get bind_device_name "$section" "bind_device_name" "${lan_device}"
+        [ ! -z "$bind_device_name" ] && [ "$bind_device" = "1" ] && device="${bind_device_name}"
+        config_get bind_interfaces "$section" "bind_interface" ""
+
+        config_get_bool "tcp_server" "$section" "tcp_server" "1"
+        config_get ipv6_server "$section" "ipv6_server" "1"
+
+        config_get extra_server_flags "$section" "server_flags" ""
+        [ -z "$extra_server_flags" ] || server_flags="$server_flags $extra_server_flags"
+        local __conf_bind_func
+        if [ ! -z $bind_interfaces ]; then
+                __conf_bind_func="conf_append_bind_interface"
+                device=${bind_interfaces}
+        else
+                __conf_bind_func="conf_append_bind"
+        fi
+
+        $__conf_bind_func "bind" "$port" "$device" "$ipv6_server" "$server_flags"
+        [ "$tcp_server" = "1" ] && $__conf_bind_func "bind-tcp" "$port" "$device" "$ipv6_server" "$server_flags"
+}
+
 conf_append_conf_files()
 {
 	local conf_file="$1"
@@ -692,7 +765,7 @@ load_service()
 	[ ! -z "$speed_check_mode" ] && conf_append "speed-check-mode" "$speed_check_mode"
 
 	config_get dualstack_ip_selection "$section" "dualstack_ip_selection" "0"
-	[ "$dualstack_ip_selection" = "0" ] && conf_append "dualstack-ip-selection" "no"
+	[ "$dualstack_ip_selection" = "0" ] && server_flags="$server_flags -no-dualstack-selection"
 
 	config_get prefetch_domain "$section" "prefetch_domain" "0"
 	[ "$prefetch_domain" = "1" ] && conf_append "prefetch-domain" "yes"
@@ -707,10 +780,10 @@ load_service()
 	[ "$resolve_local_hostnames" = "1" ] && conf_append "dnsmasq-lease-file" "$dnsmasq_lease_file"
 
 	config_get force_aaaa_soa "$section" "force_aaaa_soa" "0"
-	[ "$force_aaaa_soa" = "1" ] && qtype_soa_list="$qtype_soa_list 28"
+	[ "$force_aaaa_soa" = "1" ] && server_flags="$server_flags -force-aaaa-soa"
 
-	config_get force_https_soa "$section" "force_https_soa" "1"
-	[ "$force_https_soa" = "1" ] && qtype_soa_list="$qtype_soa_list 65"
+	config_get force_https_soa "$section" "force_https_soa" "0"
+	[ "$force_https_soa" = "1" ] && server_flags="$server_flags -force-https-soa"
 
 	config_get auto_set_dnsmasq "$section" "auto_set_dnsmasq" "1"
 
@@ -885,6 +958,7 @@ load_service()
 	[ ! -z "$bind_cert_key_pass" ] && conf_append "bind-cert-key-pass" "$bind_cert_key_pass"
 
 	load_second_server "$section"
+	config_foreach load_second_service "service"
 
 	config_foreach load_server "server"
 

--- a/package/openwrt/files/etc/init.d/smartdns
+++ b/package/openwrt/files/etc/init.d/smartdns
@@ -14,7 +14,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 START=19
 STOP=82
 NAME=smartdns
@@ -514,6 +513,44 @@ conf_append_bind()
 	done
 }
 
+conf_append_bind_interface()
+{
+	local bind_type="$1"
+	local port="$2"
+	local interfaces="$3"
+	local ipv6_server="$4"
+	local ARGS="$5"
+	local intf=""
+
+	for intf in ${interfaces}; do
+		local __device
+		local __addrs
+		network_get_device __device $intf
+		[ -z "$__device" ] && continue
+
+		if [ "$ipv6_server" = "1" ]; then
+			local __addr
+			__addr=$(ifconfig "$__device"|grep 'Scope:Link' \
+				 | sed 's:.*\(fe[8ab].*\)/.*:\1:')
+
+			[ -n "${__addr}" ] || break
+
+			conf_append "$bind_type" "[${__addr}]:${port}@${__device} $ARGS"
+
+			network_get_ipaddrs6 __addrs "$intf"
+			for __addr in ${__addrs}; do
+				[ -n "${__addr}" ] && \
+				conf_append "$bind_type" "[${__addr}]:${port}@${__device} $ARGS"
+			done
+		fi
+
+		network_get_ipaddrs __addrs "$intf"
+		for __addr in ${__addrs}; do
+			conf_append "$bind_type" "[${__addr}]:${port}@${__device} $ARGS"
+		done
+	done
+}
+
 load_second_server()
 {
 	local section="$1"
@@ -739,6 +776,7 @@ load_service()
 
 	config_get_bool bind_device "$section" "bind_device" "0"
 	config_get bind_device_name "$section" "bind_device_name" "${lan_device}"
+	config_get bind_interfaces "$section" "bind_interface" ""
 	[ ! -z "$bind_device_name" ] && [ "$bind_device" = "1" ] && device="${bind_device_name}"
 
 	config_get cache_file "$section" "cache_file" "$SMARTDNS_CONF_DIR/smartdns.cache"
@@ -829,10 +867,18 @@ load_service()
 		[ "$auto_set_dnsmasq" = "0" ] && [ "$old_auto_set_dnsmasq" = "1" ] && stop_forward_dnsmasq "$old_port" "0"
 	}
 
-	conf_append_bind "bind" "$port" "$device" "$ipv6_server" "$server_flags"
-	[ "$tcp_server" = "1" ] && conf_append_bind "bind-tcp" "$port" "$device" "$ipv6_server" "$server_flags"
-	[ "$tls_server" = "1" ] && conf_append_bind "bind-tls" "$tls_server_port" "$device" "$ipv6_server" "$server_flags"
-	[ "$doh_server" = "1" ] && conf_append_bind "bind-https" "$doh_server_port" "$device" "$ipv6_server" "$server_flags"
+	local __conf_bind_func
+	if [ ! -z $bind_interfaces ]; then
+		__conf_bind_func="conf_append_bind_interface"
+		device=${bind_interfaces}
+	else
+		__conf_bind_func="conf_append_bind"
+	fi
+
+	$__conf_bind_func "bind" "$port" "$device" "$ipv6_server" "$server_flags"
+	[ "$tcp_server" = "1" ] && $__conf_bind_func "bind-tcp" "$port" "$device" "$ipv6_server" "$server_flags"
+	[ "$tls_server" = "1" ] && $__conf_bind_func "bind-tls" "$tls_server_port" "$device" "$ipv6_server" "$server_flags"
+	[ "$doh_server" = "1" ] && $__conf_bind_func "bind-https" "$doh_server_port" "$device" "$ipv6_server" "$server_flags"
 
 	[ ! -z "$bind_cert" ] && conf_append "bind-cert-file" "$bind_cert"
 	[ ! -z "$bind_cert_key" ] && conf_append "bind-cert-key-file" "$bind_cert_key"
@@ -996,6 +1042,9 @@ start_service()
 {
 	check_and_add_entry
 	config_load "smartdns"
+
+	. /lib/functions/network.sh
+
 	config_foreach load_service "smartdns"
 }
 


### PR DESCRIPTION
The interface name defined in /etc/config/network is called logic interface name in OpenWRT. Usually, it didn't present the interface name in Linux system.

When we configure the smartdns bind to a interface, it usually means only the addresses assgined with that interface should be listened. We could have many applications bind to the same port.