### PR TITLE
fix: Ensure HTTP Host Header format compliance

### DIFF
--- a/src/dns_client.c
+++ b/src/dns_client.c
@@ -1135,7 +1135,7 @@ static int _dns_client_server_add(char *server_ip, char *server_host, int port, 
 			if (server_host) {
 				safe_strncpy(flag_https->httphost, server_host, DNS_MAX_CNAME_LEN);
 			} else {
-				safe_strncpy(flag_https->httphost, server_ip, DNS_MAX_CNAME_LEN);
+				set_http_host(server_ip, port, DEFAULT_DNS_HTTPS_PORT, flag_https->httphost);
 			}
 		}
 		sock_type = SOCK_STREAM;

--- a/src/dns_conf.c
+++ b/src/dns_conf.c
@@ -1163,7 +1163,7 @@ static int _config_server(int argc, char *argv[], dns_server_type_t type, int de
 		}
 
 		if (server->httphost[0] == '\0') {
-			safe_strncpy(server->httphost, server->server, DNS_MAX_CNAME_LEN);
+			set_http_host(server->server, server->port, DEFAULT_DNS_HTTPS_PORT, server->httphost);
 		}
 	}
 

--- a/src/util.c
+++ b/src/util.c
@@ -2225,6 +2225,23 @@ int parser_mac_address(const char *in_mac, uint8_t mac[6])
 	return -1;
 }
 
+int set_http_host(const char *uri_host, int port, int default_port, char *host)
+{
+	int is_ipv6;
+
+	if (uri_host == NULL || port <= 0 || host == NULL) {
+		return -1;
+	}
+
+	is_ipv6 = check_is_ipv6(uri_host);
+	if (port == default_port) {
+		snprintf(host, DNS_MAX_CNAME_LEN, "%s%s%s", is_ipv6 == 0 ? "[" : "", uri_host, is_ipv6 == 0 ? "]" : "");
+	} else  {
+		snprintf(host, DNS_MAX_CNAME_LEN, "%s%s%s:%d", is_ipv6 == 0 ? "[" : "", uri_host, is_ipv6 == 0 ? "]" : "", port);
+	}
+	return 0;
+}
+
 #if defined(DEBUG) || defined(TEST)
 struct _dns_read_packet_info {
 	int data_len;

--- a/src/util.h
+++ b/src/util.h
@@ -184,6 +184,8 @@ void daemon_close_stdfds(void);
 
 int write_file(const char *filename, void *data, int data_len);
 
+int set_http_host(const char *uri_host, int port, int default_port, char *host);
+
 int dns_packet_save(const char *dir, const char *type, const char *from, const void *packet, int packet_len);
 
 int dns_packet_debug(const char *packet_file);


### PR DESCRIPTION
- Non-default ports are explicitly included in the Host header
- Default ports (443 for HTTPS) are omitted
- IPv6 addresses are properly enclosed in square brackets (`[ ]`) per RFC 3986

smartdns 在发送 https 请求时，会添加 Host 字段，内容为 `https_flag->httphost`。上游为 `flag_http->httphost => server->httphost => server->server`。`server->server` 则来自配置文件中服务器地址的解析结果，当 url 中 host 为 ipv6 地址时，`util.c:parse_ip` 会移除首尾的 `[ ]`。而在 [RFC 规范](https://datatracker.ietf.org/doc/html/rfc7230#section-5.4) 中，Host 字段中的 ipv6 地址必须用方括号包裹。cloudflare 和 google 的服务器都会拒绝错误格式的 Host 字段。目前可以用 `-http-host` 选项暂时解决这个问题。

配置：

```
# cloudflare
server-https https://[2606:4700:4700::64]/dns-query
# google
server-https https://[2001:4860:4860::64]/dns-query
```

报错：

```
dns_client.c:2876] http server query from 2606:4700:4700::64:443 failed, server return http code : 403, Forbidden
dns_client.c:2876] http server query from 2001:4860:4860::64:443 failed, server return http code : 400, Bad Request
```

其他复现方式：

```
# www.google.com AAAA
curl -v 'https://[2606:4700:4700::64]:443/dns-query?dns=IlkBAAABAAAAAAAAA3d3dwZnb29nbGUDY29tAAAcAAE' -H 'Host: 2606:4700:4700::64'
curl -v 'https://[2001:4860:4860::64]:443/dns-query?dns=IlkBAAABAAAAAAAAA3d3dwZnb29nbGUDY29tAAAcAAE' -H 'Host: 2001:4860:4860::64'
```