### PR TITLE
fix build errors with ancient platforms

### DIFF
--- a/src/dns_client.c
+++ b/src/dns_client.c
@@ -332,7 +332,12 @@ static ssize_t _ssl_write_ext2(struct dns_server_info *server, SSL *ssl, const v
 #ifdef OSSL_QUIC1_VERSION
 	ret = SSL_write_ex2(ssl, buff, num, flags, &written);
 #else
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L && !defined(OPENSSL_NO_SSL_WRITE_EX)
 	ret = SSL_write_ex(ssl, buff, num, &written);
+#else
+	ret = SSL_write(ssl, buff, num);
+	written = (ret > 0) ? (size_t)ret : 0;
+#endif
 #endif
 	pthread_mutex_unlock(&server->lock);
 

--- a/src/dns_stats.c
+++ b/src/dns_stats.c
@@ -22,6 +22,8 @@
 
 struct dns_stats dns_stats;
 
+volatile char stats_lock = 0;
+
 #define SAMPLE_PERIOD 5
 
 void dns_stats_avg_time_update_add(struct dns_stats_avg_time *avg_time, uint64_t time)

--- a/src/dns_stats.h
+++ b/src/dns_stats.h
@@ -58,39 +58,68 @@ struct dns_server_stats {
 
 extern struct dns_stats dns_stats;
 
+extern volatile char stats_lock;
+
+#define ACQUIRE_LOCK()                                                                                                 \
+	do {                                                                                                               \
+		while (__sync_lock_test_and_set(&stats_lock, 1)) {                                                             \
+		}                                                                                                              \
+	} while (0)
+
+#define RELEASE_LOCK() __sync_lock_release(&stats_lock)
+
 static inline uint64_t stats_read(const uint64_t *s)
 {
-	return READ_ONCE((*s));
+	uint64_t val;
+	ACQUIRE_LOCK();
+	val = *s;
+	RELEASE_LOCK();
+	return val;
 }
 
 static inline uint64_t stats_read_and_set(uint64_t *s, uint64_t v)
 {
-	return __sync_lock_test_and_set(s, v);
+	uint64_t old_val;
+	ACQUIRE_LOCK();
+	old_val = *s;
+	*s = v;
+	RELEASE_LOCK();
+	return old_val;
 }
 
 static inline void stats_set(uint64_t *s, uint64_t v)
 {
+	ACQUIRE_LOCK();
 	*s = v;
+	RELEASE_LOCK();
 }
 
 static inline void stats_add(uint64_t *s, uint64_t v)
 {
-	(void)__sync_add_and_fetch(s, v);
+	ACQUIRE_LOCK();
+	*s += v;
+	RELEASE_LOCK();
 }
 
 static inline void stats_inc(uint64_t *s)
 {
-	(void)__sync_add_and_fetch(s, 1);
+	ACQUIRE_LOCK();
+	++(*s);
+	RELEASE_LOCK();
 }
 
 static inline void stats_sub(uint64_t *s, uint64_t v)
 {
-	(void)__sync_sub_and_fetch(s, v);
+	ACQUIRE_LOCK();
+	*s -= v;
+	RELEASE_LOCK();
 }
 
 static inline void stats_dec(uint64_t *s)
 {
-	(void)__sync_sub_and_fetch(s, 1);
+	ACQUIRE_LOCK();
+	--(*s);
+	RELEASE_LOCK();
 }
 
 void dns_stats_avg_time_update(struct dns_stats_avg_time *avg_time);


### PR DESCRIPTION
1. Fix build errors with OpenSSL 1.0.x.
2. Fix build errors with 16-bit platforms.