### PR TITLE
simplify RUST_ARCH_TARGET detection

### DIFF
--- a/plugin/smartdns-ui/Makefile
+++ b/plugin/smartdns-ui/Makefile
@@ -26,7 +26,7 @@ ifeq ($(origin CC), environment)
   ARCH=$(shell echo $(ARCH_TARGET) | cut -d - -f 1)
   ABI=$(shell echo $(ARCH_TARGET) | cut -d - -f 3)
   ifneq ($(ABI),)
-    RUST_ARCH_TARGET:=$(shell rustc --print target-list | grep $(ARCH) | grep linux | grep $(ABI) | head -n 1)
+    RUST_ARCH_TARGET:=$(shell rustc -vV | awk '/host:/ {print $$2}')
   endif
 
   ifneq ($(RUST_ARCH_TARGET),)


### PR DESCRIPTION
Replaced the previous approach of filtering target-list with grep by directly extracting the host architecture from `rustc -vV`.  This simplifies the Makefile logic and ensures accuracy.