### PR TITLE
feat(systemd/smartdns.service.in): securing systemd service

### DIFF
--- a/systemd/smartdns.service.in
+++ b/systemd/smartdns.service.in
@@ -22,8 +22,8 @@ RestartSec=2
 TimeoutStopSec=15
 
 # Capabilities
-CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_NET_ADMIN
-AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_NET_ADMIN
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_NET_ADMIN CAP_NET_RAW
+AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_NET_ADMIN CAP_NET_RAW
 
 # Hardening options
 DevicePolicy=closed

--- a/systemd/smartdns.service.in
+++ b/systemd/smartdns.service.in
@@ -9,12 +9,44 @@ StartLimitIntervalSec=60
 
 [Service]
 Type=forking
-PIDFile=@RUNSTATEDIR@/smartdns.pid
+DynamicUser=true
+RuntimeDirectory=smartdns
+LogsDirectory=smartdns
+CacheDirectory=smartdns
+PIDFile=/run/smartdns/smartdns.pid
 EnvironmentFile=@SYSCONFDIR@/default/smartdns
-ExecStart=@SBINDIR@/smartdns -p @RUNSTATEDIR@/smartdns.pid $SMART_DNS_OPTS
+LoadCredential=smartdns.conf:@SYSCONFDIR@/smartdns/smartdns.conf
+ExecStart=@SBINDIR@/smartdns -p $PIDFILE -c "${CREDENTIALS_DIRECTORY}/smartdns.conf" $SMART_DNS_OPTS
 Restart=always
 RestartSec=2
 TimeoutStopSec=15
+
+# Capabilities
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_NET_ADMIN
+AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_NET_ADMIN
+
+# Hardening options
+DevicePolicy=closed
+LockPersonality=true
+MemoryAccounting=true
+MemoryDenyWriteExecute=true
+NoNewPrivileges=true
+PrivateDevices=true
+PrivateTmp=true
+ProcSubset=pid
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHome=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectProc=invisible
+ProtectSystem=strict
+RemoveIPC=true
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
对 smartdns.service 进行加固，具体内容如下：

使用非特权用户运行服务
```
DynamicUser=yes
```

```
RuntimeDirectory=smartdns     #创建可写的 `/run/smartdns` 目录，用于PIDFile
LogsDirectory=smartdns        #创建可写的 `/var/log/smartdns` 目录，用于日志
CacheDirectory=smartdns       #创建可写的 `/var/cache/smartdns` 目录，用于持久化缓存
```

因为有了 `RuntimeDirectory`，这里不再需要 `@RUNSTATEDIR@`
```
PIDFile=/run/smartdns/smartdns.pid
```


因为 /etc/smartdns/smartdns.conf [默认](https://github.com/pymumu/smartdns/blob/05e076602e759b5af732c42c364547a7d941790c/Makefile#L67)为 root 0640 权限，使用 LoadCredential 使非特权用户可以读取配置文件。
```
LoadCredential=smartdns.conf:@SYSCONFDIR@/smartdns/smartdns.conf
```

授予运行服务所需特权：

- **CAP_NET_BIND_SERVICE** 绑定特权端口（1024以下）
- **CAP_NET_ADMIN** 管理防火墙设置，`ipset`、`nftset` 选项所必须

```
CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_NET_ADMIN
AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_NET_ADMIN
```

一大堆加固选项，具体说明可以读 systemd 文档
```
DevicePolicy=closed
LockPersonality=true
MemoryAccounting=true
MemoryDenyWriteExecute=true
NoNewPrivileges=true
PrivateDevices=true
PrivateTmp=true
ProcSubset=pid
ProtectClock=true
ProtectControlGroups=true
ProtectHome=true
ProtectHostname=true
ProtectKernelLogs=true
ProtectKernelModules=true
ProtectKernelTunables=true
ProtectProc=invisible
ProtectSystem=strict
RemoveIPC=true
RestrictNamespaces=true
RestrictRealtime=true
RestrictSUIDSGID=true
```

