### PR TITLE
openwrt: fix max-query-log-age and add plugin-dir & www-root dir conf…

### DIFF
--- a/package/openwrt/files/etc/init.d/smartdns
+++ b/package/openwrt/files/etc/init.d/smartdns
@@ -864,14 +864,16 @@ load_service()
 
 	[ "$ui" = "1" ] && {
 		config_get ui_port "$section" "ui_port" "6080"
+		config_get ui_plugin "$section" "ui_plugin" "/usr/lib/libsmartdns_ui.so"
+		config_get ui_wwwroot "$section" "ui_wwwroot" "/usr/share/smartdns/wwwroot"
 		config_get ui_data_dir "$section" "ui_data_dir" "/var/lib/smartdns"
 		config_get ui_log_max_age "$section" "ui_log_max_age" "30"
-
-		conf_append "plugin" "/usr/lib/libsmartdns_ui.so"
-		conf_append "smartdns-ui.www-root" "/usr/share/smartdns/wwwroot"
+ 		ui_log_max_age_s=$((ui_log_max_age * 86400))
+		conf_append "plugin" "$ui_plugin"
+		conf_append "smartdns-ui.www-root" "$ui_wwwroot"
 		conf_append "smartdns-ui.ip" "http://0.0.0.0:$ui_port"
 		conf_append "data-dir" "$ui_data_dir"
-		conf_append "smartdns-ui.max-query-log-age" "$ui_log_max_age"
+		conf_append "smartdns-ui.max-query-log-age" "$ui_log_max_age_s"
 	}
 
 	{


### PR DESCRIPTION
…iguration

according to https://github.com/pymumu/smartdns/blob/afaad9b529525e9a44e1d39176b611bad6707630/etc/smartdns/smartdns.conf#L448

与https://github.com/pymumu/luci-app-smartdns/pull/85 一起完成对 plugin dir 和www-root dir的自定义支持，并修复了max-query-log-age的单位。 如果没有问题，请与 https://github.com/pymumu/luci-app-smartdns/pull/85 一起合并。谢谢。