### PR TITLE
openwrt: fix max-query-log-age

### DIFF
--- a/package/openwrt/files/etc/init.d/smartdns
+++ b/package/openwrt/files/etc/init.d/smartdns
@@ -867,11 +867,13 @@ load_service()
 		config_get ui_data_dir "$section" "ui_data_dir" "/var/lib/smartdns"
 		config_get ui_log_max_age "$section" "ui_log_max_age" "30"
 
+                ui_log_max_age_s=$((ui_log_max_age * 86400))
+
 		conf_append "plugin" "smartdns_ui.so"
 		conf_append "smartdns-ui.www-root" "/usr/share/smartdns/wwwroot"
 		conf_append "smartdns-ui.ip" "http://0.0.0.0:$ui_port"
 		conf_append "data-dir" "$ui_data_dir"
-		conf_append "smartdns-ui.max-query-log-age" "$ui_log_max_age"
+		conf_append "smartdns-ui.max-query-log-age" "$ui_log_max_age_s"
 	}
 
 	{


### PR DESCRIPTION
according to https://github.com/pymumu/smartdns/blob/afaad9b529525e9a44e1d39176b611bad6707630/etc/smartdns/smartdns.conf#L448