### PR TITLE
ensure db into `auto_vacuum = FULL` mode and reduce `-wal` file size

### DIFF
--- a/plugin/smartdns-ui/src/db.rs
+++ b/plugin/smartdns-ui/src/db.rs
@@ -384,12 +384,23 @@ impl DB {
         conn.as_ref()
             .unwrap()
             .execute("PRAGMA auto_vacuum = FULL", [])?;
+        let avt: i64 = conn
+            .as_ref()
+            .unwrap()
+            .query_row("PRAGMA auto_vacuum;", [], |r| r.get(0))?;
+        if avt != 1 {
+            conn.as_ref().unwrap().execute_batch("VACUUM;")?;
+        }
         conn.as_ref()
             .unwrap()
             .query_row("PRAGMA journal_mode = WAL", [], |_| Ok(()))?;
         conn.as_ref()
             .unwrap()
-            .query_row("PRAGMA wal_autocheckpoint = 50000", [], |_| Ok(()))?;
+            .query_row("PRAGMA wal_autocheckpoint = 3000", [], |_| Ok(()))?;
+        let _ = conn
+            .as_ref()
+            .unwrap()
+            .execute_batch("PRAGMA wal_checkpoint(TRUNCATE); PRAGMA optimize;");
         Ok(())
     }
 


### PR DESCRIPTION
as per https://github.com/pymumu/smartdns/issues/2109#issuecomment-3240668630 and after this pr...

first run from completely new installation:
```
root@:~# rm -rf /var/lib/smartdns/*.*
root@:~# /etc/init.d/smartdns start
root@:~# sqlite3 /tmp/lib/smartdns/smartdns.db "PRAGMA auto_vacuum;"
1
```
transfer existing db into `auto_vacuum` FULL mode
```
root@:~# sqlite3 /tmp/lib/smartdns/smartdns.db "PRAGMA auto_vacuum=NONE; VACUUM; PRAGMA auto_vacuum;"
0
root@:~# /etc/init.d/smartdns restart
root@:~# sqlite3 /tmp/lib/smartdns/smartdns.db "PRAGMA auto_vacuum;"
1
```