### PR TITLE
fix: allow set and default empty server name

### DIFF
--- a/package/luci-compat/files/luci/model/cbi/smartdns/smartdns.lua
+++ b/package/luci-compat/files/luci/model/cbi/smartdns/smartdns.lua
@@ -45,9 +45,9 @@ o.rempty      = false
 
 ---- server name
 o = s:taboption("settings", Value, "server_name", translate("Server Name"), translate("Smartdns server name"))
-o.default     = "smartdns"
+o.placeholder = "server name"
 o.datatype    = "hostname"
-o.rempty      = false
+o.rempty      = true
 
 ---- Port
 o = s:taboption("settings", Value, "port", translate("Local Port"), 

--- a/package/luci/files/root/www/luci-static/resources/view/smartdns/smartdns.js
+++ b/package/luci/files/root/www/luci-static/resources/view/smartdns/smartdns.js
@@ -149,9 +149,9 @@ return view.extend({
 
 		// server name;
 		o = s.taboption("settings", form.Value, "server_name", _("Server Name"), _("Smartdns server name"));
-		o.default = "smartdns";
+		o.placeholder = "server name";
 		o.datatype = "hostname";
-		o.rempty = false;
+		o.rempty = true;
 
 		// Port;
 		o = s.taboption("settings", form.Value, "port", _("Local Port"),


### PR DESCRIPTION
中文翻译中明确说明 server name 设置为空时使用主机名，但是多年来 luci 页面并不允许其设置为空。
本提交使默认值变为占位符并允许默认值为空。

fix: #2173