### PR TITLE
fix stat not refresh while domain table has little data

### DIFF
--- a/plugin/smartdns-ui/src/data_stats.rs
+++ b/plugin/smartdns-ui/src/data_stats.rs
@@ -421,15 +421,13 @@ impl DataStats {
             .db
             .delete_domain_before_timestamp(now - self.conf.read().unwrap().max_log_age_ms as u64);
         if let Err(e) = ret {
-            if e.to_string() == "Query returned no rows" {
-                return;
-            }
-
-            dns_log!(
+            if e.to_string() != "Query returned no rows" {
+              dns_log!(
                 LogLevel::WARN,
                 "delete domain before timestamp error: {}",
                 e
-            );
+              );
+            }
         }
 
         let ret = self.db.refresh_client_top_list(now - 7 * 24 * 3600 * 1000);


### PR DESCRIPTION
纠正当domain表数据很少（不触发rotate）时统计数据不更新问题 #2297
此处如果return了，下面的refresh就不会执行，导致最多查询客户端、最多查询域名不更新