### PR TITLE
Modify serve_expired logic to include 'no' option

### DIFF
--- a/package/openwrt/files/etc/init.d/smartdns
+++ b/package/openwrt/files/etc/init.d/smartdns
@@ -672,7 +672,11 @@ load_service()
 	[ "$prefetch_domain" = "1" ] && conf_append "prefetch-domain" "yes"
 
 	config_get serve_expired "$section" "serve_expired" "0"
-	[ "$serve_expired" = "1" ] && conf_append "serve-expired" "yes"
+	if [ "$serve_expired" = "1" ]; then
+		conf_append "serve-expired" "yes"
+	else
+		conf_append "serve-expired" "no"
+	fi
 
 	config_get cache_size "$section" "cache_size" ""
 	[ -z "$cache_size" ] || conf_append "cache-size" "$cache_size"


### PR DESCRIPTION
https://github.com/pymumu/smartdns/pull/2302
修改的时候发现缓存过期服务关闭也是开启的状态！
增加日志发现始终是group_rule->dns_serve_expired = 1;