### PR TITLE
fix logs written via stdio delayed

### DIFF
--- a/src/tlog.c
+++ b/src/tlog.c
@@ -23,6 +23,7 @@
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <sys/uio.h>
 #include <unistd.h>
 
 #ifndef likely
@@ -739,9 +740,14 @@ int tlog_stdout_with_color(tlog_level level, const char *buff, int bufflen)
     }
 
     if (color != NULL) {
-        fprintf(stdout, "%s%.*s\033[0m\n", color, bufflen - 1, buff);
+        struct iovec buff_iov[3] = {
+            { .iov_base = color, .iov_len = strlen(color) },
+            { .iov_base = buff,  .iov_len = bufflen - 1 },
+            { .iov_base = "\033[0m\n", .iov_len = 5 }
+        };
+        unused = writev(STDOUT_FILENO, buff_iov, 3);
     } else {
-        fprintf(stdout, "%s", buff);
+        unused = write(STDOUT_FILENO, buff, bufflen);
     }
 
     return bufflen;    


### PR DESCRIPTION
https://github.com/pymumu/smartdns/commit/52a35a5f887535ce33b3731592a33e86ec7d3066 将stdout输出从 write(STDOUT_FILENO)改为fprintf(stdout)。在容器环境（stdout 为 pipe、stdio 全缓冲）下可能导致日志输出卡在用户态缓冲。此时如果plugin调用tlog，在程序退出时可能会导致资源释放先于tlog缓冲输出而产生崩溃。 https://github.com/pymumu/smartdns/blob/0c3fdd0e98e6e7672f7af02591ae385e3c8733bd/src/dns_plugin.c#L304-L307 
------------^*此处建议删除dlclose()，可以有效避免退出时崩溃*

本次提交弃用fprint，引入 iovec 将数据一次性提交给 write(STDOUT_FILENO)，避免了stdio缓冲和字符串拼接，同时不影响现有功能。

相关日志如下：
```
localhost:~# docker logs smartdns36
....此前省略
[2026-04-14 01:04:15,515][ WARN][     client_tcp.c:185 ] http server query from 116.63.10.31:443 failed, server return http code : 502, Bad Gateway
[2026-04-14 01:53:17,639][ WARN][     client_tls.c:1023] Handshake with 94.140.14.49 failed, error no: unexpected eof while reading(-1, 1, 294)
localhost:~# cat /userdata/smartdns/log/smartdns.log
....此前省略
[2026-04-14 01:04:15,515][ WARN][     client_tcp.c:185 ] http server query from 116.63.10.31:443 failed, server return http code : 502, Bad Gateway
[2026-04-14 01:53:17,639][ WARN][     client_tls.c:1023] Handshake with 94.140.14.49 failed, error no: unexpected eof while reading(-1, 1, 294)
[2026-04-14 03:15:33,517][ WARN][     client_tcp.c:185 ] http server query from 116.63.10.31:443 failed, server return http code : 502, Bad Gateway <----log文件内容比容器日志多
[2026-04-14 03:27:12,518][ WARN][     client_tcp.c:185 ] http server query from 116.63.10.31:443 failed, server return http code : 502, Bad Gateway
[2026-04-14 03:38:08,518][ WARN][     client_tcp.c:185 ] http server query from 116.63.10.31:443 failed, server return http code : 502, Bad Gateway
[2026-04-14 04:19:29,512][ WARN][     client_tcp.c:185 ] http server query from 116.63.10.31:443 failed, server return http code : 502, Bad Gateway
[2026-04-14 09:04:51,517][ WARN][     client_tcp.c:185 ] http server query from 116.63.10.31:443 failed, server return http code : 502, Bad Gateway
[2026-04-14 09:14:06,518][ WARN][     client_tcp.c:185 ] http server query from 116.63.10.31:443 failed, server return http code : 502, Bad Gateway
[2026-04-14 09:24:48,417][ WARN][     client_tcp.c:185 ] http server query from 116.63.10.31:443 failed, server return http code : 502, Bad Gateway
localhost:~# docker restart smartdns36 && docker logs smartdns36
....此前省略
[2026-04-14 01:04:15,515][ WARN][     client_tcp.c:185 ] http server query from 116.63.10.31:443 failed, server return http code : 502, Bad Gateway
[2026-04-14 01:53:17,639][ WARN][     client_tls.c:1023] Handshake with 94.140.14.49 failed, error no: unexpected eof while reading(-1, 1, 294)
[2026-04-14 03:15:33,517][ WARN][     client_tcp.c:185 ] http server query from 116.63.10.31:443 failed, server return http code : 502, Bad Gateway <----程序退出后缓冲区日志出现
[2026-04-14 03:27:12,518][ WARN][     client_tcp.c:185 ] http server query from 116.63.10.31:443 failed, server return http code : 502, Bad Gateway
[2026-04-14 03:38:08,518][ WARN][     client_tcp.c:185 ] http server query from 116.63.10.31:443 failed, server return http code : 502, Bad Gateway
[2026-04-14 04:19:29,512][ WARN][     client_tcp.c:185 ] http server query from 116.63.10.31:443 failed, server return http code : 502, Bad Gateway
[2026-04-14 09:04:51,517][ WARN][     client_tcp.c:185 ] http server query from 116.63.10.31:443 failed, server return http code : 502, Bad Gateway
[2026-04-14 09:14:06,518][ WARN][     client_tcp.c:185 ] http server query from 116.63.10.31:443 failed, server return http code : 502, Bad Gateway
[2026-04-14 09:24:48,417][ WARN][     client_tcp.c:185 ] http server query from 116.63.10.31:443 failed, server return http code : 502, Bad Gateway
```
```
[2026-03-14 16:48:29,621][FATAL][       smartdns.c:763 ] process exit with signal 11, code = 1, errno = 0, pid = -1588840152, self = 6, pc = 0x738b8133, addr = 0x2a14c3928, build(1.2025.v47.1.38 x86_64) 
[2026-03-14 16:48:29,622][FATAL][          stack.c:83  ] Stack:
[2026-03-14 16:48:29,622][FATAL][          stack.c:95  ] #01: 0x564697c6a5e3 print_stack() from /usr/sbin/smartdns+0x6a5e3
[2026-03-14 16:48:29,622][FATAL][          stack.c:95  ] #02: 0x564697c1c47f () from /usr/sbin/smartdns+0x1c47f
[2026-03-14 16:48:29,622][FATAL][          stack.c:95  ] #03: 0x7f4248743f42 () from /lib/ld-musl-x86_64.so.1+0x5ef42
[2026-03-14 17:02:13,482][FATAL][       smartdns.c:763 ] process exit with signal 11, code = 1, errno = 0, pid = -1185723240, self = 7, pc = 0xffffffffe1218c55, addr = 0x6b9534c98, build(1.2025.v47.1.39 x86_64)
[2026-03-14 17:02:13,483][FATAL][          stack.c:83  ] Stack:
[2026-03-14 17:02:13,483][FATAL][          stack.c:95  ] #01: 0x558c64e6a5e3 print_stack() from /usr/sbin/smartdns+0x6a5e3
[2026-03-14 17:02:13,483][FATAL][          stack.c:95  ] #02: 0x558c64e1c47f () from /usr/sbin/smartdns+0x1c47f
[2026-03-14 17:02:13,483][FATAL][          stack.c:95  ] #03: 0x7f3a0be11f42 () from /lib/ld-musl-x86_64.so.1+0x5ef42
[2026-03-14 17:09:45,678][FATAL][       smartdns.c:763 ] process exit with signal 11, code = 1, errno = 0, pid = 279921264, self = 7, pc = 0x5c856642, addr = 0x310af4270, build(1.2025.v47.1.39 x86_64)
[2026-03-14 17:09:45,679][FATAL][          stack.c:83  ] Stack:
[2026-03-14 17:09:45,679][FATAL][          stack.c:95  ] #01: 0x55edc826a5e3 print_stack() from /usr/sbin/smartdns+0x6a5e3
[2026-03-14 17:09:45,679][FATAL][          stack.c:95  ] #02: 0x55edc821c47f () from /usr/sbin/smartdns+0x1c47f
[2026-03-14 17:09:45,679][FATAL][          stack.c:95  ] #03: 0x7f52eba22f42 () from /lib/ld-musl-x86_64.so.1+0x5ef42
```