### PR TITLE
fix(openwrt): handle CIDR in LAN IP when setting DHCP DNS

### DIFF
--- a/package/openwrt/files/etc/init.d/smartdns
+++ b/package/openwrt/files/etc/init.d/smartdns
@@ -83,6 +83,12 @@ set_main_dns()
 {
 	local hostip
 	hostip="$(uci -q get network.lan.ipaddr | sed 's/\/.*//g')"
+	case "$hostip" in
+	 */*)
+	  hostip="${hostip%%/*}"
+	  ;;
+	esac
+
 	dnsmasq_port="$(uci -q get dhcp.@dnsmasq[0].port)"
 	[ -z "$dnsmasq_port" ] && dnsmasq_port="53"
 	


### PR DESCRIPTION
On OpenWrt, network.lan.ipaddr may be returned in CIDR form (e.g. 192.168.50.1/24). The init script was using this value as-is, resulting in an invalid DHCP option like:

    6,192.168.50.1/24

Some clients reject this and DNS breaks.

Strip the subnet suffix before adding the DHCP option so only the plain IP is used.

If the value does not contain a CIDR suffix, it is left unchanged.

Fixes #2321