### PR TITLE
Add error handling for DNS cache hash table allocation

### DIFF
--- a/src/dns_cache.c
+++ b/src/dns_cache.c
@@ -1031,12 +1031,12 @@ void dns_cache_destroy(void)
 		return;
 	}
 
+	is_cache_init = 0;
+
 	dns_cache_flush();
 
 	pthread_mutex_destroy(&dns_cache_head.lock);
 	hash_table_free(dns_cache_head.cache_hash, free);
-
-	is_cache_init = 0;
 }
 
 int dns_cache_foreach(dns_cache_foreach_cb cb, void *userdata)

--- a/src/dns_cache.c
+++ b/src/dns_cache.c
@@ -506,6 +506,10 @@ int dns_cache_insert(struct dns_cache_key *cache_key, int rcode, int ttl, int sp
 
 int dns_cache_update_timer(struct dns_cache_key *key, int timeout)
 {
+	if (dns_cache_head.size <= 0) {
+		return -1;
+	}
+
 	struct dns_cache *dns_cache = _dns_cache_lookup(key);
 	if (dns_cache == NULL) {
 		return -1;
@@ -1031,6 +1035,7 @@ void dns_cache_destroy(void)
 		return;
 	}
 
+	dns_cache_head.size = 0;
 	dns_cache_flush();
 
 	pthread_mutex_destroy(&dns_cache_head.lock);

--- a/src/dns_cache.c
+++ b/src/dns_cache.c
@@ -72,6 +72,11 @@ int dns_cache_init(int size, int mem_size, dns_cache_callback timeout_callback)
 	}
 
 	hash_table_init(dns_cache_head.cache_hash, bits);
+	if (dns_cache_head.cache_hash.table == NULL) {
+		tlog(TLOG_ERROR, "init dns cache failed, alloc hash table failed, bits = %d", bits);
+		return -1;
+	}
+
 	atomic_set(&dns_cache_head.num, 0);
 	atomic_set(&dns_cache_head.mem_size, 0);
 	dns_cache_head.size = size;

--- a/src/dns_cache.c
+++ b/src/dns_cache.c
@@ -1031,12 +1031,12 @@ void dns_cache_destroy(void)
 		return;
 	}
 
-	is_cache_init = 0;
-
 	dns_cache_flush();
 
 	pthread_mutex_destroy(&dns_cache_head.lock);
 	hash_table_free(dns_cache_head.cache_hash, free);
+
+	is_cache_init = 0;
 }
 
 int dns_cache_foreach(dns_cache_foreach_cb cb, void *userdata)


### PR DESCRIPTION
`hash_table_init` 会先写入 size，再 calloc 分配 `table`，可能在内存紧张场景下出现“size 有值、table 为 NULL”的不一致状态。本提交在`hash_table_init`后检查 dns_cache_head.cache_hash.table，若分配失败则立即返回，避免后续调用导致崩溃 #2320 #2323