### PR TITLE
fix: avoid closing reused http2 stream twice

### DIFF
--- a/src/dns_server/server_http2.c
+++ b/src/dns_server/server_http2.c
@@ -109,7 +109,7 @@ static void _dns_server_http2_process_stream(struct dns_server_conn_tls_client *
 		char *base64_query = NULL;
 
 		if (http2_stream_get_ex_data(stream)) {
-			goto close_out;
+			return;
 		}
 		http2_stream_set_ex_data(stream, (void *)1);
 


### PR DESCRIPTION
## Summary
- fix the HTTP/2 stream handling path in `server_http2.c`
- return early when a stream has already been marked as processed, instead of jumping into the close path
- avoid duplicate close/cleanup behavior for reused streams

## Why
使用浏览器时，存在 soa 记录的地址会导致无法访问，即使 ipv4 存在