### PR TITLE
capability: add DAC_READ_SEARCH for file access after dropping root

### DIFF
--- a/src/utils/capbility.c
+++ b/src/utils/capbility.c
@@ -99,8 +99,8 @@ int drop_root_privilege(void)
 
 	prctl(PR_SET_KEEPCAPS, 1, 0, 0, 0);
 	for (int i = 0; i < 2; i++) {
-		cap[i].effective = (1 << CAP_NET_RAW | 1 << CAP_NET_ADMIN | 1 << CAP_NET_BIND_SERVICE);
-		cap[i].permitted = (1 << CAP_NET_RAW | 1 << CAP_NET_ADMIN | 1 << CAP_NET_BIND_SERVICE);
+		cap[i].effective = (1 << CAP_NET_RAW | 1 << CAP_NET_ADMIN | 1 << CAP_NET_BIND_SERVICE | 1 << CAP_DAC_READ_SEARCH);
+		cap[i].permitted = (1 << CAP_NET_RAW | 1 << CAP_NET_ADMIN | 1 << CAP_NET_BIND_SERVICE | 1 << CAP_DAC_READ_SEARCH);
 	}
 
 	unused = setgid(gid);

--- a/src/utils/misc.c
+++ b/src/utils/misc.c
@@ -65,10 +65,18 @@ int create_dir_with_perm(const char *dir_path)
 	uid_t uid = 0;
 	gid_t gid = 0;
 	struct stat sb;
+	struct stat path_sb;
 	char data_dir[PATH_MAX] = {0};
 	int unused __attribute__((unused)) = 0;
 
 	safe_strncpy(data_dir, dir_path, PATH_MAX);
+
+	if (stat(dir_path, &path_sb) == 0) {
+		if (!S_ISREG(path_sb.st_mode) && !S_ISDIR(path_sb.st_mode)) {
+			return 0;
+		}
+	}
+
 	dir_name(data_dir);
 
 	if (get_uid_gid(&uid, &gid) != 0) {


### PR DESCRIPTION
## Changes:
- src/utils/capbility.c: Add CAP_DAC_READ_SEARCH
  to effective/permitted sets in drop_root_privilege().
- src/utils/misc.c: Skip create_dir_with_perm() when target path exists
  but is not a regular file or directory (e.g., socket/device node).

## 场景
1 当 tls 证书目录在非工作目录时，即使 root 用户，提示启动错误 `error:8000000D:system library::Permission denied`

2 当配置以下时，create_dir_with_perm() 函数会错误地将其当作目录路径，并尝试创建或修改该路径，这会引发系统问题
```
log-file /dev/null
log-console yes
user nobody
```