### PR TITLE
dns_conf_group: remove redundant checks

### DIFF
--- a/src/dns_conf/dns_conf_group.c
+++ b/src/dns_conf/dns_conf_group.c
@@ -471,10 +471,6 @@ void _dns_conf_group_post(void)
 			group->dns_rr_ttl_min = group->dns_rr_ttl_max;
 		}
 
-		if ((group->dns_rr_ttl_max < group->dns_rr_ttl_min) && group->dns_rr_ttl_max > 0) {
-			group->dns_rr_ttl_max = group->dns_rr_ttl_min;
-		}
-
 		if (group->dns_serve_expired == 1 && group->dns_serve_expired_ttl == 0) {
 			group->dns_serve_expired_ttl = DNS_MAX_SERVE_EXPIRED_TIME;
 		}


### PR DESCRIPTION
When cache is disabled and the config file does not specify `rr-ttl-min`, the hardcoded `dns_rr_ttl_min` causes a TTL of 600 to always be returned. So `dns_rr_ttl_min` should be removed to ensure behavior consistent with the documentation.

After line 469 is executed, the second if {} will never be executed, so it should be removed.