### PR TITLE
修正不正常的http请求导致程序进程重启

### DIFF
--- a/src/http_parse/http1_parse.c
+++ b/src/http_parse/http1_parse.c
@@ -23,6 +23,8 @@
 #include <stdio.h>
 #include <unistd.h>
 
+#define HTTP_MAX_CHUNK_SIZE (64 * 1024)
+
 static int _http_head_parse_response(struct http_head *http_head, char *key, char *value)
 {
 	char *field_start = NULL;
@@ -204,6 +206,10 @@ static int _http1_get_chunk_len(const uint8_t *data, int data_len, int32_t *chun
 			is_num_start = 1;
 		}
 
+		if (chunk_value > (HTTP_MAX_CHUNK_SIZE >> 4)) {
+			return -2;
+		}
+		
 		chunk_value = (chunk_value << 4) + value;
 	}
 


### PR DESCRIPTION
当一个http请求假装自己过长时发生溢出，进而导致进程重启而没有任何崩溃日志。
现在限制一个请求内容不超过64KB，当收到无效或错误长度时返回，避免崩溃。

以下由AI生成：

**问题**
_http1_get_chunk_len() 中使用 int32_t chunk_value 逐位左移累加十六进制 chunk 大小，未对 chunk_value 做上限检查。当攻击者发送超过 0x7FFFFFFF 的 chunk 大小（如 F0000000、FFFFFFFFF）时：

chunk_value << 4 触发有符号整数溢出（C 标准未定义行为）
溢出后 chunk_value 变为负数，导致后续 data_len < chunk_len 检查被绕过（负数 < 正数恒成立）
进而可能触发堆缓冲区溢出

**修复**
新增 #define HTTP_MAX_CHUNK_SIZE (64 * 1024)，在 chunk_value << 4 之前检查当前值是否已超过 HTTP_MAX_CHUNK_SIZE >> 4（即 0x1000 / 4096），若超过则立即返回 -2（解析错误）。

```
#define HTTP_MAX_CHUNK_SIZE (64 * 1024)

// 在 _http1_get_chunk_len() 的 for 循环中，<< 4 之前插入：
if (chunk_value > (HTTP_MAX_CHUNK_SIZE >> 4)) {
    return -2;
}
```

**原理**
每个十六进制位将 chunk_value 扩大 16 倍（<< 4）。在移位前检查当前值 > MAX >> 4，等价于确保移位后 ≤ MAX，且移位后值仍为正数（最大 0xFFFFF，远小于 INT32_MAX）
同时防止了 有符号整数溢出：0xFFFFF 在任何左移次数下都不会触及 INT32_MAX (0x7FFFFFFF)
64KB 限制对 DNS-over-HTTP 场景完全合理（DNS 消息上限 65535 字节）
发现问题时立即返回 -2，不做任何越界操作，符合"尽早终止"原则