### PR TITLE
Fix HPACK encoder initial dynamic table size

### DIFF
--- a/src/http_parse/http2.c
+++ b/src/http_parse/http2.c
@@ -98,6 +98,7 @@ const char *http2_error_to_string(int ret)
 #define HTTP2_FRAME_HEADER_SIZE 9
 #define HTTP2_MAX_HEADER_TABLE_SIZE 65536
 #define HTTP2_MAX_HEADER_BLOCK_SIZE 65536
+#define HTTP2_INITIAL_HEADER_TABLE_SIZE 4096 /* RFC 7540 Section 6.5.2 */
 #define HTTP2_CONNECTION_PREFACE "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
 #define HTTP2_CONNECTION_PREFACE_LEN 24
 
@@ -1933,6 +1934,11 @@ static void _http2_ctx_init_common(struct http2_ctx *ctx, const struct http2_ctx
 
 	hpack_init_context(&ctx->encoder);
 	hpack_init_context(&ctx->decoder);
+
+	/* Per RFC 7540 Section 6.5.2, the initial SETTINGS_HEADER_TABLE_SIZE
+	 * from the peer is 4096 until explicitly updated by the peer's SETTINGS
+	 * frame (processed in _http2_process_settings_frame). */
+	ctx->encoder.max_dynamic_table_size = HTTP2_INITIAL_HEADER_TABLE_SIZE;
 
 	hash_init(ctx->stream_map);
 	INIT_LIST_HEAD(&ctx->streams);


### PR DESCRIPTION
RFC 7540 规定 SETTINGS_HEADER_TABLE_SIZE 默认值是4096。smartdns在初始化时会向客户端发送 Settings - Header table size : 65536（也就是hpack->max_dynamic_table_size = 65536; /* Default size */）。但在客户端没有发送SETTINGS_HEADER_TABLE_SIZE时，应该默认客户端能接受的表大小是默认值，即4096。

本提交在连接初始化后将Header table size  设为 4096，避免一方未发送 setting 时两侧表大小不一致导致的索引越界问题。修改同时作用于smartdns作为server和client端。修改仅改变编码器初始值，不改变编码器初始值或大小。