### PR TITLE
nftset: support multiple targets per domain rule

### DIFF
--- a/src/dns_conf/domain_rule.c
+++ b/src/dns_conf/domain_rule.c
@@ -186,6 +186,27 @@ static void _rule_txt_clone(struct dns_rule *new_rule, struct dns_rule *old_rule
 	}
 }
 
+static void _rule_nftset_clone(struct dns_rule *new_rule, struct dns_rule *old_rule)
+{
+	struct dns_nftset_rule *new_nft = (struct dns_nftset_rule *)new_rule;
+	struct dns_nftset_rule *old_nft = (struct dns_nftset_rule *)old_rule;
+	struct dns_nftset_rule *prev = new_nft;
+
+	new_nft->next = NULL;
+	for (old_nft = old_nft->next; old_nft; old_nft = old_nft->next) {
+		struct dns_nftset_rule *copy = (struct dns_nftset_rule *)_new_dns_rule(old_rule->rule);
+		if (!copy) {
+			break;
+		}
+		copy->familyname = old_nft->familyname;
+		copy->nfttablename = old_nft->nfttablename;
+		copy->nftsetname = old_nft->nftsetname;
+		copy->next = NULL;
+		prev->next = copy;
+		prev = copy;
+	}
+}
+
 static struct dns_rule_info dns_rule_info_table[DOMAIN_RULE_MAX] = {
 	[DOMAIN_RULE_FLAGS] = {sizeof(struct dns_rule_flags), NULL, NULL},
 	[DOMAIN_RULE_ADDRESS_IPV4] = {sizeof(struct dns_rule_address_IPV4), _rule_address_ipv4_get_size, NULL},
@@ -193,10 +214,10 @@ static struct dns_rule_info dns_rule_info_table[DOMAIN_RULE_MAX] = {
 	[DOMAIN_RULE_NAMESERVER] = {sizeof(struct dns_nameserver_rule), NULL, NULL},
 	[DOMAIN_RULE_CHECKSPEED] = {sizeof(struct dns_domain_check_orders), NULL, NULL},
 	[DOMAIN_RULE_IPSET] = {sizeof(struct dns_ipset_rule), NULL, NULL},
-	[DOMAIN_RULE_NFTSET_IP] = {sizeof(struct dns_nftset_rule), NULL, NULL},
+	[DOMAIN_RULE_NFTSET_IP] = {sizeof(struct dns_nftset_rule), NULL, _rule_nftset_clone},
 	[DOMAIN_RULE_IPSET_IPV4] = {sizeof(struct dns_ipset_rule), NULL, NULL},
 	[DOMAIN_RULE_GROUP] = {sizeof(struct dns_group_rule), NULL, NULL},
-	[DOMAIN_RULE_NFTSET_IP6] = {sizeof(struct dns_nftset_rule), NULL, NULL},
+	[DOMAIN_RULE_NFTSET_IP6] = {sizeof(struct dns_nftset_rule), NULL, _rule_nftset_clone},
 	[DOMAIN_RULE_IPSET_IPV6] = {sizeof(struct dns_ipset_rule), NULL, NULL},
 	[DOMAIN_RULE_HTTPS] = {sizeof(struct dns_https_record_rule), NULL, _rule_https_clone},
 	[DOMAIN_RULE_SRV] = {sizeof(struct dns_srv_record_rule), NULL, _rule_srv_clone},
@@ -304,6 +325,14 @@ static void _dns_rule_free(struct dns_rule *rule)
 				list_del(&record->list);
 				free(record);
 			}
+		}
+	} else if (rule->rule == DOMAIN_RULE_NFTSET_IP || rule->rule == DOMAIN_RULE_NFTSET_IP6) {
+		struct dns_nftset_rule *nft = ((struct dns_nftset_rule *)rule)->next;
+		while (nft) {
+			struct dns_nftset_rule *tmp_nft = nft->next;
+			nft->next = NULL;
+			_dns_rule_put(&nft->head);
+			nft = tmp_nft;
 		}
 	}
 	free(rule);
@@ -699,6 +728,28 @@ int _config_domain_rule_add(const char *domain, enum domain_rule type, void *rul
 	}
 
 	if (domain_rule->rules[type]) {
+		/* nftset: append to chain instead of replacing, so multiple
+		 * nftset targets for the same domain are all preserved. */
+		if (type == DOMAIN_RULE_NFTSET_IP || type == DOMAIN_RULE_NFTSET_IP6) {
+			struct dns_nftset_rule *tail = (struct dns_nftset_rule *)domain_rule->rules[type];
+			struct dns_nftset_rule *new_nft = (struct dns_nftset_rule *)prule;
+			while (tail->next) {
+				tail = tail->next;
+			}
+			new_nft->next = NULL;
+			if (!is_cloned) {
+				_dns_rule_get(prule);
+			}
+			tail->next = new_nft;
+			if (add_domain_rule) {
+				old_domain_rule = art_insert(&_config_current_rule_group()->domain_rule.tree,
+							     (unsigned char *)domain_key, len, add_domain_rule);
+				if (old_domain_rule) {
+					_config_domain_rule_free(old_domain_rule);
+				}
+			}
+			return 0;
+		}
 		_dns_rule_put(domain_rule->rules[type]);
 		domain_rule->rules[type] = NULL;
 	}

--- a/src/dns_server/ipset_nftset.c
+++ b/src/dns_server/ipset_nftset.c
@@ -41,23 +41,21 @@ void _dns_server_add_ipset_nftset(struct dns_request *request, struct dns_ipset_
 		}
 	}
 
-	if (nftset_rule != NULL) {
-		/* add IPV4 to ipset */
+	for (const struct dns_nftset_rule *cur = nftset_rule; cur; cur = cur->next) {
 		if (addr_len == DNS_RR_A_LEN) {
 			tlog(TLOG_DEBUG, "NFTSET-MATCH: domain: %s, nftset: %s %s %s, IP: %d.%d.%d.%d", request->domain,
-				 nftset_rule->familyname, nftset_rule->nfttablename, nftset_rule->nftsetname, addr[0], addr[1], addr[2],
-				 addr[3]);
-			nftset_add(nftset_rule->familyname, nftset_rule->nfttablename, nftset_rule->nftsetname, addr, DNS_RR_A_LEN,
+				 cur->familyname, cur->nfttablename, cur->nftsetname, addr[0], addr[1], addr[2], addr[3]);
+			nftset_add(cur->familyname, cur->nfttablename, cur->nftsetname, addr, DNS_RR_A_LEN,
 					   nftset_timeout_value);
 		} else if (addr_len == DNS_RR_AAAA_LEN) {
 			tlog(TLOG_DEBUG,
 				 "NFTSET-MATCH: domain: %s, nftset: %s %s %s, IP: "
 				 "%.2x%.2x:%.2x%.2x:%.2x%.2x:%.2x%.2x:%.2x%.2x:%.2x%.2x:%.2x%.2x:%.2x%.2x",
-				 request->domain, nftset_rule->familyname, nftset_rule->nfttablename, nftset_rule->nftsetname, addr[0],
-				 addr[1], addr[2], addr[3], addr[4], addr[5], addr[6], addr[7], addr[8], addr[9], addr[10], addr[11],
-				 addr[12], addr[13], addr[14], addr[15]);
-			nftset_add(nftset_rule->familyname, nftset_rule->nfttablename, nftset_rule->nftsetname, addr,
-					   DNS_RR_AAAA_LEN, nftset_timeout_value);
+				 request->domain, cur->familyname, cur->nfttablename, cur->nftsetname, addr[0], addr[1], addr[2],
+				 addr[3], addr[4], addr[5], addr[6], addr[7], addr[8], addr[9], addr[10], addr[11], addr[12],
+				 addr[13], addr[14], addr[15]);
+			nftset_add(cur->familyname, cur->nfttablename, cur->nftsetname, addr, DNS_RR_AAAA_LEN,
+					   nftset_timeout_value);
 		}
 	}
 }

--- a/src/include/smartdns/dns_conf.h
+++ b/src/include/smartdns/dns_conf.h
@@ -260,6 +260,7 @@ struct dns_nftset_rule {
 	const char *familyname;
 	const char *nfttablename;
 	const char *nftsetname;
+	struct dns_nftset_rule *next;
 };
 
 struct dns_nftset_names {


### PR DESCRIPTION
## Summary

Fix `domain-rules -nftset` to support multiple nftset targets for the same domain.

Currently, when a domain has multiple nftset targets (different nftables tables), only the **last** target takes effect. Both comma-separated syntax and multiple directives exhibit this behavior:

```
# Only the last nftset target (table2#set2) is populated
nftset /domain/#4:inet#table1#set1,#4:inet#table2#set2

# Same result: only table2#set2 gets IPs
domain-rules /domain-set:list/ -nftset #4:inet#table1#set1
domain-rules /domain-set:list/ -nftset #4:inet#table2#set2
```

**Root cause**: `_config_domain_rule_add()` stores one rule per type in `rules[type]`. When called twice with the same type (`DOMAIN_RULE_NFTSET_IP`), the second call releases and overwrites the first.

## Changes

Chain nftset rules via a `next` pointer (singly-linked list), following the same pattern used by HTTPS/SRV/TXT record rules:

- `dns_conf.h`: Add `struct dns_nftset_rule *next` field
- `domain_rule.c`: Append instead of replace for nftset types; add clone callback and chain cleanup in `_dns_rule_free`
- `ipset_nftset.c`: Iterate the chain in `_dns_server_add_ipset_nftset`

3 files, +62/-12 lines. Builds cleanly with zero new warnings.

## Use case

Routing CN domain resolved IPs to multiple nftables tables (tproxy bypass + killswitch accept) on an OpenWrt router. Without this fix, a watchdog-based workaround is required to sync sets between tables.

Fixes #1944