### PR TITLE
check Content-Encoding value only, no infer

### DIFF
--- a/src/http_parse/http2.c
+++ b/src/http_parse/http2.c
@@ -2704,12 +2704,12 @@ static int http2_try_decompress_body(struct http2_stream *stream)
 	if (content_encoding) {
 		is_gzip = (strcasecmp(content_encoding, "gzip") == 0);
 		int is_deflate = (strcasecmp(content_encoding, "deflate") == 0);
-		should_decompress = (is_gzip || is_deflate);
-	} else if (stream->body_buffer_len > 2) {
-		/* Fallback: check for gzip magic number (0x1f 0x8b) */
-		if (stream->body_buffer[0] == 0x1f && stream->body_buffer[1] == 0x8b) {
-			is_gzip = 1;
+		if (is_gzip || is_deflate) {
 			should_decompress = 1;
+		} else {
+			/* Unsupported Content-Encoding */
+			errno = ENOTSUP;
+			return -1;
 		}
 	}
 
@@ -2729,6 +2729,7 @@ static int http2_try_decompress_body(struct http2_stream *stream)
 		} else {
 			/* Decompression failed, set an error flag or log */
 			/* For now, leave body_decompressed = 0, and let read_body handle error */
+			errno = EINVAL;
 			return -1; /* Indicate failure */
 		}
 	}


### PR DESCRIPTION
去掉根据报文头猜测gzip的代码，严格根据 Content-Encoding 检查压缩方式。
对于未实现的方式或多重压缩显式返回不支持
fix #2403