### PR TITLE
feat: add MINIMAL=1 build option for upstream UDP/TCP only

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -100,6 +100,30 @@ ifeq ($(USE_ATOMIC), 0)
  override LDFLAGS += -latomic 
 endif
 
+# Minimal build: only support upstream UDP/TCP servers, no TLS/HTTPS/QUIC/HTTP3/mDNS
+ifdef MINIMAL
+override CFLAGS += -DMINIMAL_BUILD
+override OBJS := $(filter-out \
+	dns_client/client_tls.o \
+	dns_client/client_https.o \
+	dns_client/client_http2.o \
+	dns_client/client_quic.o \
+	dns_client/client_http3.o \
+	dns_client/client_mdns.o \
+	dns_server/server_tls.o \
+	dns_server/server_https.o \
+	dns_server/server_http2.o \
+	dns_server/server_http.o \
+	dns_server/mdns.o \
+	utils/ssl.o \
+	http_parse/http_parse.o \
+	http_parse/http1_parse.o \
+	http_parse/http2.o \
+	http_parse/http3_parse.o \
+	, $(OBJS))
+override LDFLAGS := $(filter-out -lssl -lcrypto, $(LDFLAGS))
+endif
+
 override LDFLAGS += $(EXTRA_LDFLAGS)
 
 .PHONY: all clean

--- a/src/dns_client/client_socket.c
+++ b/src/dns_client/client_socket.c
@@ -17,16 +17,20 @@
  */
 
 #include "client_socket.h"
+#ifndef MINIMAL_BUILD
 #include "client_http3.h"
 #include "client_https.h"
-#include "client_mdns.h"
 #include "client_quic.h"
-#include "client_tcp.h"
 #include "client_tls.h"
+#endif
+#include "client_mdns.h"
+#include "client_tcp.h"
 #include "client_udp.h"
 #include "conn_stream.h"
 
+#ifndef MINIMAL_BUILD
 #include <openssl/ssl.h>
+#endif
 #include <sys/epoll.h>
 
 int _dns_client_create_socket(struct dns_server_info *server_info)
@@ -44,10 +48,13 @@ int _dns_client_create_socket(struct dns_server_info *server_info)
 
 	if (server_info->type == DNS_SERVER_UDP) {
 		ret = _dns_client_create_socket_udp(server_info);
+#ifndef MINIMAL_BUILD
 	} else if (server_info->type == DNS_SERVER_MDNS) {
 		ret = _dns_client_create_socket_udp_mdns(server_info);
+#endif
 	} else if (server_info->type == DNS_SERVER_TCP) {
 		ret = _dns_client_create_socket_tcp(server_info);
+#ifndef MINIMAL_BUILD
 	} else if (server_info->type == DNS_SERVER_TLS) {
 		struct client_dns_server_flag_tls *flag_tls = NULL;
 		flag_tls = &server_info->flags.tls;
@@ -76,6 +83,7 @@ int _dns_client_create_socket(struct dns_server_info *server_info)
 			alpn = flag_https->alpn;
 		}
 		ret = _dns_client_create_socket_quic(server_info, flag_https->hostname, alpn);
+#endif
 	} else {
 		ret = -1;
 	}
@@ -87,12 +95,13 @@ int _dns_client_create_socket(struct dns_server_info *server_info)
 
 void _dns_client_close_socket_ext(struct dns_server_info *server_info, int no_del_conn_list)
 {
-	dns_server_status server_status = DNS_SERVER_STATUS_DISCONNECTED;
-
 	pthread_mutex_lock(&server_info->lock);
-	server_status = server_info->status;
+#ifndef MINIMAL_BUILD
+	dns_server_status server_status = server_info->status;
+#endif
 	server_info->status = DNS_SERVER_STATUS_DISCONNECTED;
 
+#ifndef MINIMAL_BUILD
 	if (server_info->ssl) {
 		/* Shutdown ssl */
 		if (server_status == DNS_SERVER_STATUS_CONNECTED) {
@@ -157,6 +166,7 @@ void _dns_client_close_socket_ext(struct dns_server_info *server_info, int no_de
 		BIO_meth_free(server_info->bio_method);
 		server_info->bio_method = NULL;
 	}
+#endif
 
 	if (server_info->proxy) {
 		proxy_conn_free(server_info->proxy);
@@ -201,6 +211,7 @@ void _dns_client_shutdown_socket(struct dns_server_info *server_info)
 			shutdown(server_info->fd, SHUT_RDWR);
 		}
 		break;
+#ifndef MINIMAL_BUILD
 	case DNS_SERVER_QUIC:
 	case DNS_SERVER_TLS:
 	case DNS_SERVER_HTTP3:
@@ -214,6 +225,7 @@ void _dns_client_shutdown_socket(struct dns_server_info *server_info)
 		}
 		atomic_set(&server_info->is_alive, 0);
 		break;
+#endif
 	case DNS_SERVER_MDNS:
 		break;
 	default:
@@ -227,6 +239,7 @@ int _dns_client_socket_send(struct dns_server_info *server_info)
 		return -1;
 	} else if (server_info->type == DNS_SERVER_TCP) {
 		return send(server_info->fd, server_info->send_buff.data, server_info->send_buff.len, MSG_NOSIGNAL);
+#ifndef MINIMAL_BUILD
 	} else if (server_info->type == DNS_SERVER_TLS || server_info->type == DNS_SERVER_HTTPS ||
 			   server_info->type == DNS_SERVER_QUIC || server_info->type == DNS_SERVER_HTTP3) {
 		int write_len = server_info->send_buff.len;
@@ -244,6 +257,7 @@ int _dns_client_socket_send(struct dns_server_info *server_info)
 			}
 		}
 		return ret;
+#endif
 	} else if (server_info->type == DNS_SERVER_MDNS) {
 		return -1;
 	} else {
@@ -258,6 +272,7 @@ int _dns_client_socket_recv(struct dns_server_info *server_info)
 	} else if (server_info->type == DNS_SERVER_TCP) {
 		return recv(server_info->fd, server_info->recv_buff.data + server_info->recv_buff.len,
 					DNS_TCP_BUFFER - server_info->recv_buff.len, 0);
+#ifndef MINIMAL_BUILD
 	} else if (server_info->type == DNS_SERVER_TLS || server_info->type == DNS_SERVER_HTTPS ||
 			   server_info->type == DNS_SERVER_QUIC || server_info->type == DNS_SERVER_HTTP3) {
 		int ret = _dns_client_socket_ssl_recv(server_info, server_info->recv_buff.data + server_info->recv_buff.len,
@@ -270,6 +285,7 @@ int _dns_client_socket_recv(struct dns_server_info *server_info)
 		}
 
 		return ret;
+#endif
 	} else if (server_info->type == DNS_SERVER_MDNS) {
 		return -1;
 	} else {

--- a/src/dns_client/client_tcp.c
+++ b/src/dns_client/client_tcp.c
@@ -18,16 +18,19 @@
 
 #define _GNU_SOURCE
 
-#include "smartdns/http_parse.h"
 #include "smartdns/lib/stringutil.h"
 #include "smartdns/util.h"
 
-#include "client_https.h"
 #include "client_socket.h"
 #include "client_tcp.h"
-#include "client_tls.h"
 #include "conn_stream.h"
 #include "server_info.h"
+
+#ifndef MINIMAL_BUILD
+#include "smartdns/http_parse.h"
+#include "client_https.h"
+#include "client_tls.h"
+#endif
 
 #include <net/if.h>
 #include <netinet/ip.h>
@@ -150,6 +153,7 @@ errout:
 	return -1;
 }
 
+#ifndef MINIMAL_BUILD
 static int _dns_client_process_tcp_buff(struct dns_server_info *server_info)
 {
 	int len = 0;
@@ -252,7 +256,9 @@ out:
 	}
 	return ret;
 }
+#endif
 
+#ifndef MINIMAL_BUILD
 static int _dns_client_process_https_streams(struct dns_server_info *server_info)
 {
 	struct dns_conn_stream *stream, *tmp;
@@ -313,6 +319,7 @@ errout:
 	ret = -1;
 	goto out;
 }
+#endif
 int _dns_client_process_tcp(struct dns_server_info *server_info, struct epoll_event *event, unsigned long now)
 {
 	int len = 0;
@@ -364,9 +371,11 @@ int _dns_client_process_tcp(struct dns_server_info *server_info, struct epoll_ev
 			return 0;
 		}
 
+#ifndef MINIMAL_BUILD
 		if (_dns_client_process_tcp_buff(server_info) != 0) {
 			goto errout;
 		}
+#endif
 	}
 
 	/* when connected */
@@ -400,12 +409,14 @@ int _dns_client_process_tcp(struct dns_server_info *server_info, struct epoll_ev
 			pthread_mutex_unlock(&client.server_list_lock);
 		}
 
+#ifndef MINIMAL_BUILD
 		/* Process HTTPS streams if any */
 		if (server_info->type == DNS_SERVER_HTTPS && server_info->send_buff.len == 0) {
 			if (_dns_client_process_https_streams(server_info) != 0) {
 				goto errout;
 			}
 		}
+#endif
 
 		/* still remain data, retry */
 		if (server_info->send_buff.len > 0) {

--- a/src/dns_client/conn_stream.c
+++ b/src/dns_client/conn_stream.c
@@ -57,6 +57,7 @@ void _dns_client_conn_stream_put(struct dns_conn_stream *stream)
 		return;
 	}
 
+#ifndef MINIMAL_BUILD
 	if (stream->quic_stream) {
 		SSL_free(stream->quic_stream);
 		stream->quic_stream = NULL;
@@ -68,6 +69,7 @@ void _dns_client_conn_stream_put(struct dns_conn_stream *stream)
 		http2_stream_close(http2_stream);
 		stream->server_info = NULL;
 	}
+#endif
 
 	if (stream->query) {
 		pthread_mutex_lock(&stream->query->lock);
@@ -100,6 +102,7 @@ void _dns_client_conn_server_streams_free(struct dns_server_info *server_info, s
 
 		list_del_init(&stream->server_list);
 		stream->server_info = NULL;
+#ifndef MINIMAL_BUILD
 		if (stream->quic_stream) {
 #if defined(OSSL_QUIC1_VERSION) && !defined(OPENSSL_NO_QUIC)
 			SSL_stream_reset(stream->quic_stream, NULL, 0);
@@ -112,6 +115,7 @@ void _dns_client_conn_server_streams_free(struct dns_server_info *server_info, s
 			http2_stream_close(stream->http2_stream);
 			stream->http2_stream = NULL;
 		}
+#endif
 
 		_dns_client_conn_stream_put(stream);
 	}

--- a/src/dns_client/dns_client.c
+++ b/src/dns_client/dns_client.c
@@ -20,14 +20,16 @@
 
 #include "smartdns/util.h"
 
+#ifndef MINIMAL_BUILD
 #include "client_http2.h"
 #include "client_http3.h"
 #include "client_https.h"
-#include "client_mdns.h"
 #include "client_quic.h"
+#include "client_tls.h"
+#endif
+#include "client_mdns.h"
 #include "client_socket.h"
 #include "client_tcp.h"
-#include "client_tls.h"
 #include "client_udp.h"
 #include "conn_stream.h"
 #include "dns_client.h"
@@ -212,10 +214,12 @@ static int _dns_client_process(struct dns_server_info *server_info, struct epoll
 	} else if (server_info->type == DNS_SERVER_TCP) {
 		/* receive from tcp */
 		return _dns_client_process_tcp(server_info, event, now);
+#ifndef MINIMAL_BUILD
 	} else if (server_info->type == DNS_SERVER_TLS || server_info->type == DNS_SERVER_HTTPS ||
 			   server_info->type == DNS_SERVER_QUIC || server_info->type == DNS_SERVER_HTTP3) {
 		/* receive from tls */
 		return _dns_client_process_tls(server_info, event, now);
+#endif
 	} else {
 		return -1;
 	}
@@ -223,6 +227,7 @@ static int _dns_client_process(struct dns_server_info *server_info, struct epoll
 	return 0;
 }
 
+#ifndef MINIMAL_BUILD
 static int _dns_client_send_http(struct dns_server_info *server_info, struct dns_query_struct *query, void *packet_data,
 								 int packet_data_len)
 {
@@ -235,6 +240,7 @@ static int _dns_client_send_http(struct dns_server_info *server_info, struct dns
 	   If ALPN later turns out to be H1, _dns_client_process_https_streams will handle it. */
 	return _dns_client_send_http2(server_info, query, packet_data, packet_data_len);
 }
+#endif
 
 static int _dns_client_check_server_prohibit(struct dns_server_info *server_info, int prohibit_time)
 {
@@ -289,6 +295,7 @@ static int _dns_client_send_one_packet(struct dns_server_info *server_info, stru
 			ret = _dns_client_send_tcp(server_info, packet_data, packet_data_len);
 			send_err = errno;
 			break;
+#ifndef MINIMAL_BUILD
 		case DNS_SERVER_TLS:
 			/* tls query */
 			ret = _dns_client_send_tls(server_info, packet_data, packet_data_len);
@@ -297,11 +304,6 @@ static int _dns_client_send_one_packet(struct dns_server_info *server_info, stru
 		case DNS_SERVER_HTTPS:
 			/* https query - buffer raw data in stream, protocol determined later */
 			ret = _dns_client_send_http(server_info, query, packet_data, packet_data_len);
-			send_err = errno;
-			break;
-		case DNS_SERVER_MDNS:
-			/* mdns query */
-			ret = _dns_client_send_udp_mdns(server_info, packet_data, packet_data_len);
 			send_err = errno;
 			break;
 		case DNS_SERVER_QUIC:
@@ -314,6 +316,14 @@ static int _dns_client_send_one_packet(struct dns_server_info *server_info, stru
 			ret = _dns_client_send_http3(query, server_info, packet_data, packet_data_len);
 			send_err = errno;
 			break;
+#endif
+#ifndef MINIMAL_BUILD
+		case DNS_SERVER_MDNS:
+			/* mdns query */
+			ret = _dns_client_send_udp_mdns(server_info, packet_data, packet_data_len);
+			send_err = errno;
+			break;
+#endif
 		default:
 			/* unsupported query type */
 			ret = -1;
@@ -710,10 +720,12 @@ int dns_client_init(void)
 		goto errout;
 	}
 
+#ifndef MINIMAL_BUILD
 	if (_dns_client_add_mdns_server() != 0) {
 		tlog(TLOG_ERROR, "add mdns server failed.");
 		goto errout;
 	}
+#endif
 
 	client.default_group = _dns_client_get_group(DNS_SERVER_GROUP_DEFAULT);
 	client.epoll_fd = epollfd;
@@ -781,6 +793,7 @@ void dns_client_exit(void)
 
 	pthread_mutex_destroy(&client.server_list_lock);
 	pthread_mutex_destroy(&client.domain_map_lock);
+#ifndef MINIMAL_BUILD
 	if (client.ssl_ctx) {
 		SSL_CTX_free(client.ssl_ctx);
 		client.ssl_ctx = NULL;
@@ -790,6 +803,7 @@ void dns_client_exit(void)
 		SSL_CTX_free(client.ssl_quic_ctx);
 		client.ssl_quic_ctx = NULL;
 	}
+#endif
 
 	is_client_init = 0;
 }

--- a/src/dns_client/dns_client.h
+++ b/src/dns_client/dns_client.h
@@ -22,16 +22,31 @@
 #include "smartdns/dns.h"
 #include "smartdns/dns_conf.h"
 #include "smartdns/dns_stats.h"
+#ifndef MINIMAL_BUILD
 #include "smartdns/http2.h"
-#include "smartdns/lib/atomic.h"
-#include "smartdns/lib/hashtable.h"
-#include "smartdns/lib/list.h"
-#include "smartdns/tlog.h"
-
 #include <openssl/err.h>
 #include <openssl/rand.h>
 #include <openssl/ssl.h>
 #include <openssl/x509v3.h>
+#else
+struct ssl_st;
+struct ssl_ctx_st;
+struct ssl_session_st;
+struct bio_method_st;
+typedef struct ssl_st SSL;
+typedef struct ssl_ctx_st SSL_CTX;
+typedef struct ssl_session_st SSL_SESSION;
+typedef struct bio_method_st BIO_METHOD;
+#include <errno.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <time.h>
+#include <unistd.h>
+#endif
+#include "smartdns/lib/atomic.h"
+#include "smartdns/lib/hashtable.h"
+#include "smartdns/lib/list.h"
+#include "smartdns/tlog.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/dns_client/query.c
+++ b/src/dns_client/query.c
@@ -332,9 +332,13 @@ int _dns_client_add_hashmap(struct dns_query_struct *query)
 	int loop = 0;
 
 	while (loop++ <= 32) {
+#ifndef MINIMAL_BUILD
 		if (RAND_bytes((unsigned char *)&query->sid, sizeof(query->sid)) != 1) {
 			query->sid = random();
 		}
+#else
+		query->sid = random();
+#endif
 
 		key = hash_string(query->domain);
 		key = jhash(&query->sid, sizeof(query->sid), key);

--- a/src/dns_client/server_info.c
+++ b/src/dns_client/server_info.c
@@ -20,7 +20,9 @@
 
 #include "server_info.h"
 #include "client_socket.h"
+#ifndef MINIMAL_BUILD
 #include "client_tls.h"
+#endif
 #include "conn_stream.h"
 #include "ecs.h"
 #include "group.h"
@@ -328,6 +330,7 @@ int _dns_client_server_add(const char *server_ip, const char *server_host, int p
 
 		sock_type = SOCK_DGRAM;
 	} break;
+#ifndef MINIMAL_BUILD
 	case DNS_SERVER_HTTP3: {
 		struct client_dns_server_flag_https *flag_https = &flags->https;
 		spki_data_len = flag_https->spi_len;
@@ -366,6 +369,7 @@ int _dns_client_server_add(const char *server_ip, const char *server_host, int p
 		sock_type = SOCK_STREAM;
 		skip_check_cert = flag_tls->skip_check_cert;
 	} break;
+#endif
 	case DNS_SERVER_TCP:
 		sock_type = SOCK_STREAM;
 		break;
@@ -449,6 +453,7 @@ int _dns_client_server_add(const char *server_ip, const char *server_host, int p
 		goto errout;
 	}
 
+#ifndef MINIMAL_BUILD
 	/* if server type is TLS, create ssl context */
 	if (server_type == DNS_SERVER_TLS || server_type == DNS_SERVER_HTTPS || server_type == DNS_SERVER_QUIC ||
 		server_type == DNS_SERVER_HTTP3) {
@@ -466,6 +471,7 @@ int _dns_client_server_add(const char *server_ip, const char *server_host, int p
 			server_info->skip_check_cert = 1;
 		}
 	}
+#endif
 
 	/* safe address info */
 	if (gai->ai_addrlen > sizeof(server_info->in6)) {
@@ -581,12 +587,14 @@ void _dns_client_server_close(struct dns_server_info *server_info)
 
 	_dns_client_close_socket(server_info);
 
+#ifndef MINIMAL_BUILD
 	if (server_info->ssl_session) {
 		SSL_SESSION_free(server_info->ssl_session);
 		server_info->ssl_session = NULL;
 	}
 
 	server_info->ssl_ctx = NULL;
+#endif
 }
 
 /* remove all servers information */

--- a/src/dns_conf/bind.c
+++ b/src/dns_conf/bind.c
@@ -367,6 +367,7 @@ static int _config_bind_ip(int argc, char *argv[], DNS_BIND_TYPE type)
 	bind_ip->flags = server_flag;
 	bind_ip->group = group;
 	dns_conf.bind_ip_num++;
+#ifndef MINIMAL_BUILD
 	if (bind_ip->type == DNS_BIND_TYPE_TLS || bind_ip->type == DNS_BIND_TYPE_HTTPS) {
 		if (bind_ip->ssl_cert_file == NULL || bind_ip->ssl_cert_key_file == NULL) {
 			bind_ip->ssl_cert_file = dns_conf.bind_ca_file;
@@ -375,6 +376,7 @@ static int _config_bind_ip(int argc, char *argv[], DNS_BIND_TYPE type)
 		}
 		dns_conf.need_cert = 1;
 	}
+#endif
 	tlog(TLOG_DEBUG, "bind ip %s, type: %d, flag: %X", ip, type, server_flag);
 
 	return 0;
@@ -434,6 +436,7 @@ int _config_bind_ip_tcp(void *data, int argc, char *argv[])
 	return _config_bind_ip(argc, argv, DNS_BIND_TYPE_TCP);
 }
 
+#ifndef MINIMAL_BUILD
 int _config_bind_ip_tls(void *data, int argc, char *argv[])
 {
 	return _config_bind_ip(argc, argv, DNS_BIND_TYPE_TLS);
@@ -448,3 +451,4 @@ int _config_bind_ip_http(void *data, int argc, char *argv[])
 {
 	return _config_bind_ip(argc, argv, DNS_BIND_TYPE_HTTP);
 }
+#endif

--- a/src/dns_conf/bind.h
+++ b/src/dns_conf/bind.h
@@ -29,9 +29,11 @@ extern "C" {
 int _config_add_default_server_if_needed(void);
 int _config_bind_ip_udp(void *data, int argc, char *argv[]);
 int _config_bind_ip_tcp(void *data, int argc, char *argv[]);
+#ifndef MINIMAL_BUILD
 int _config_bind_ip_tls(void *data, int argc, char *argv[]);
 int _config_bind_ip_https(void *data, int argc, char *argv[]);
 int _config_bind_ip_http(void *data, int argc, char *argv[]);
+#endif
 
 void dns_server_bind_destroy(void);
 

--- a/src/dns_conf/dns_conf.c
+++ b/src/dns_conf/dns_conf.c
@@ -89,6 +89,7 @@ static int _config_option_parser_filepath(void *data, int argc, char *argv[])
 	return 0;
 }
 
+#ifndef MINIMAL_BUILD
 static int _config_bind_cert_san(void *data, int argc, char *argv[])
 {
 	char *san = data;
@@ -121,6 +122,7 @@ static int _config_bind_cert_san(void *data, int argc, char *argv[])
 
 	return 0;
 }
+#endif
 
 static int _config_log_level(void *data, int argc, char *argv[])
 {
@@ -174,9 +176,12 @@ static struct config_item _config_item[] = {
 	CONF_YESNO("resolv-hostname", &dns_conf.resolv_hostname),
 	CONF_CUSTOM("bind", _config_bind_ip_udp, NULL),
 	CONF_CUSTOM("bind-tcp", _config_bind_ip_tcp, NULL),
+#ifndef MINIMAL_BUILD
 	CONF_CUSTOM("bind-tls", _config_bind_ip_tls, NULL),
 	CONF_CUSTOM("bind-https", _config_bind_ip_https, NULL),
 	CONF_CUSTOM("bind-http", _config_bind_ip_http, NULL),
+#endif
+#ifndef MINIMAL_BUILD
 	CONF_CUSTOM("bind-cert-root-key-file", _config_option_parser_filepath, &dns_conf.bind_root_ca_key_file),
 	CONF_YESNOAUTO("bind-cert-generate", &dns_conf.bind_cert_generate),
 	CONF_CUSTOM("bind-cert-san", _config_bind_cert_san, dns_conf.bind_cert_san),
@@ -184,13 +189,16 @@ static struct config_item _config_item[] = {
 	CONF_CUSTOM("bind-cert-file", _config_option_parser_filepath, &dns_conf.bind_ca_file),
 	CONF_CUSTOM("bind-cert-key-file", _config_option_parser_filepath, &dns_conf.bind_ca_key_file),
 	CONF_STRING("bind-cert-key-pass", dns_conf.bind_ca_key_pass, DNS_MAX_PATH),
+#endif
 	CONF_CUSTOM("server", _config_server_udp, NULL),
 	CONF_CUSTOM("server-tcp", _config_server_tcp, NULL),
+#ifndef MINIMAL_BUILD
 	CONF_CUSTOM("server-tls", _config_server_tls, NULL),
 	CONF_CUSTOM("server-https", _config_server_https, NULL),
 	CONF_CUSTOM("server-h3", _config_server_http3, NULL),
 	CONF_CUSTOM("server-http3", _config_server_http3, NULL),
 	CONF_CUSTOM("server-quic", _config_server_quic, NULL),
+#endif
 	CONF_YESNO("mdns-lookup", &dns_conf.mdns_lookup),
 	CONF_YESNO("local-ptr-enable", &dns_conf.local_ptr_enable),
 	CONF_CUSTOM("nameserver", _config_nameserver, NULL),

--- a/src/dns_conf/https_record.c
+++ b/src/dns_conf/https_record.c
@@ -145,13 +145,15 @@ int _conf_domain_rule_https_record(const char *domain, const char *host)
 					goto errout;
 				}
 				record->alpn_len = alpn_len;
-			} else if (strncmp(key, "ech", sizeof("ech")) == 0) {
+	#ifndef MINIMAL_BUILD
+		} else if (strncmp(key, "ech", sizeof("ech")) == 0) {
 				int ech_len = SSL_base64_decode(val, record->ech, DNS_MAX_ECH_LEN);
 				if (ech_len < 0) {
 					tlog(TLOG_ERROR, "invalid option value for %s.", key);
 					goto errout;
 				}
 				record->ech_len = ech_len;
+#endif
 			} else if (strncmp(key, "ipv4hint", sizeof("ipv4hint")) == 0) {
 				int addr_len = DNS_RR_A_LEN;
 				if (get_raw_addr_by_ip(val, record->ipv4_addr, &addr_len) != 0) {

--- a/src/dns_conf/server.c
+++ b/src/dns_conf/server.c
@@ -131,6 +131,7 @@ static int _config_server(int argc, char *argv[], dns_server_type_t type, int de
 		}
 	}
 
+#ifndef MINIMAL_BUILD
 	if (dns_is_quic_supported() == 0) {
 		if (type == DNS_SERVER_QUIC || type == DNS_SERVER_HTTP3) {
 			tlog(TLOG_ERROR, "QUIC/HTTP3 is not supported in this version.");
@@ -138,6 +139,7 @@ static int _config_server(int argc, char *argv[], dns_server_type_t type, int de
 			return -1;
 		}
 	}
+#endif
 
 	/* if port is not defined, set port to default 53 */
 	if (port == PORT_NOT_DEFINED) {
@@ -367,6 +369,7 @@ int _config_server_tcp(void *data, int argc, char *argv[])
 	return _config_server(argc, argv, DNS_SERVER_TCP, DEFAULT_DNS_PORT);
 }
 
+#ifndef MINIMAL_BUILD
 int _config_server_tls(void *data, int argc, char *argv[])
 {
 	return _config_server(argc, argv, DNS_SERVER_TLS, DEFAULT_DNS_TLS_PORT);
@@ -395,3 +398,4 @@ int _config_server_http3(void *data, int argc, char *argv[])
 
 	return ret;
 }
+#endif

--- a/src/dns_conf/server.h
+++ b/src/dns_conf/server.h
@@ -28,10 +28,12 @@ extern "C" {
 
 int _config_server_udp(void *data, int argc, char *argv[]);
 int _config_server_tcp(void *data, int argc, char *argv[]);
+#ifndef MINIMAL_BUILD
 int _config_server_tls(void *data, int argc, char *argv[]);
 int _config_server_https(void *data, int argc, char *argv[]);
 int _config_server_quic(void *data, int argc, char *argv[]);
 int _config_server_http3(void *data, int argc, char *argv[]);
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/dns_server/connection.c
+++ b/src/dns_server/connection.c
@@ -22,7 +22,9 @@
 
 #include "smartdns/http2.h"
 
+#ifndef MINIMAL_BUILD
 #include <openssl/ssl.h>
+#endif
 #include <sys/epoll.h>
 #include <sys/eventfd.h>
 
@@ -56,6 +58,7 @@ void _dns_server_conn_release(struct dns_server_conn_head *conn)
 		return;
 	}
 
+#ifndef MINIMAL_BUILD
 	if (conn->type == DNS_CONN_TYPE_TLS_CLIENT || conn->type == DNS_CONN_TYPE_HTTPS_CLIENT) {
 		struct dns_server_conn_tls_client *tls_client = (struct dns_server_conn_tls_client *)conn;
 		if (tls_client->ssl != NULL) {
@@ -81,6 +84,7 @@ void _dns_server_conn_release(struct dns_server_conn_head *conn)
 			http2_stream->stream = NULL;
 		}
 	}
+#endif
 
 	if (conn->fd > 0) {
 		close(conn->fd);
@@ -112,6 +116,7 @@ void _dns_server_close_socket(void)
 	pthread_mutex_lock(&server.conn_list_lock);
 	list_for_each_entry_safe(conn, tmp, &server.conn_list, list)
 	{
+#ifndef MINIMAL_BUILD
 		/* Force cleanup of TLS/HTTPS client connections to prevent memory leaks */
 		if (conn->type == DNS_CONN_TYPE_TLS_CLIENT || conn->type == DNS_CONN_TYPE_HTTPS_CLIENT) {
 			struct dns_server_conn_tls_client *tls_client = (struct dns_server_conn_tls_client *)conn;
@@ -122,6 +127,7 @@ void _dns_server_close_socket(void)
 				tls_client->ssl = NULL;
 			}
 		}
+#endif
 
 		_dns_server_client_close(conn);
 	}
@@ -135,17 +141,18 @@ void _dns_server_close_socket_server(void)
 
 	list_for_each_entry_safe(conn, tmp, &server.conn_list, list)
 	{
-		switch (conn->type) {
-		case DNS_CONN_TYPE_HTTPS_SERVER:
-		case DNS_CONN_TYPE_TLS_SERVER: {
+#ifndef MINIMAL_BUILD
+		if (conn->type == DNS_CONN_TYPE_HTTPS_SERVER || conn->type == DNS_CONN_TYPE_TLS_SERVER) {
 			struct dns_server_conn_tls_server *tls_server = (struct dns_server_conn_tls_server *)conn;
 			if (tls_server->ssl_ctx) {
 				SSL_CTX_free(tls_server->ssl_ctx);
 				tls_server->ssl_ctx = NULL;
 			}
 			_dns_server_client_close(conn);
-			break;
+			continue;
 		}
+#endif
+		switch (conn->type) {
 		case DNS_CONN_TYPE_HTTP_SERVER:
 		case DNS_CONN_TYPE_UDP_SERVER:
 		case DNS_CONN_TYPE_TCP_SERVER:
@@ -172,6 +179,7 @@ int _dns_server_client_close(struct dns_server_conn_head *conn)
 	list_del_init(&conn->list);
 	pthread_mutex_unlock(&server.conn_list_lock);
 
+#ifndef MINIMAL_BUILD
 	if (conn->type == DNS_CONN_TYPE_TLS_CLIENT || conn->type == DNS_CONN_TYPE_HTTPS_CLIENT) {
 		struct dns_server_conn_tls_client *tls_client = (struct dns_server_conn_tls_client *)conn;
 		if (tls_client->http2_ctx != NULL) {
@@ -179,6 +187,7 @@ int _dns_server_client_close(struct dns_server_conn_head *conn)
 			tls_client->http2_ctx = NULL;
 		}
 	}
+#endif
 
 	_dns_server_conn_release(conn);
 

--- a/src/dns_server/dns_server.c
+++ b/src/dns_server/dns_server.c
@@ -32,19 +32,23 @@
 #include "dualstack.h"
 #include "ip_rule.h"
 #include "local_addr.h"
+#ifndef MINIMAL_BUILD
 #include "mdns.h"
+#endif
 #include "neighbor.h"
 #include "ptr.h"
 #include "request.h"
 #include "request_pending.h"
 #include "rules.h"
+#ifndef MINIMAL_BUILD
 #include "server_https.h"
-#include "server_socket.h"
-#include "server_tcp.h"
 #include "server_tls.h"
-#include "server_udp.h"
 #include "server_http2.h"
 #include "server_http.h"
+#endif
+#include "server_socket.h"
+#include "server_tcp.h"
+#include "server_udp.h"
 #include "soa.h"
 #include "speed_check.h"
 
@@ -96,6 +100,7 @@ int _dns_reply_inpacket(struct dns_request *request, unsigned char *inpacket, in
 		ret = _dns_server_reply_udp(request, (struct dns_server_conn_udp *)conn, inpacket, inpacket_len);
 	} else if (conn->type == DNS_CONN_TYPE_TCP_CLIENT) {
 		ret = _dns_server_reply_tcp(request, (struct dns_server_conn_tcp_client *)conn, inpacket, inpacket_len);
+#ifndef MINIMAL_BUILD
 	} else if (conn->type == DNS_CONN_TYPE_TLS_CLIENT) {
 		ret = _dns_server_reply_tcp(request, (struct dns_server_conn_tcp_client *)conn, inpacket, inpacket_len);
 	} else if (conn->type == DNS_CONN_TYPE_HTTPS_CLIENT) {
@@ -104,6 +109,7 @@ int _dns_reply_inpacket(struct dns_request *request, unsigned char *inpacket, in
 		ret = _dns_server_reply_http(request, (struct dns_server_conn_tcp_client *)conn, inpacket, inpacket_len);
 	} else if (conn->type == DNS_CONN_TYPE_HTTP2_STREAM) {
 		ret = _dns_server_reply_http2(request, (struct dns_server_conn_http2_stream *)conn, inpacket, inpacket_len);
+#endif
 	} else {
 		ret = -1;
 	}
@@ -248,7 +254,9 @@ int _dns_server_do_query(struct dns_request *request, int skip_notify_event)
 	const char *server_group_name = NULL;
 	struct dns_query_options options;
 	char *request_domain = request->domain;
+#ifndef MINIMAL_BUILD
 	char domain_buffer[DNS_MAX_CNAME_LEN * 2];
+#endif
 
 	request->send_tick = get_tick_count();
 
@@ -265,10 +273,12 @@ int _dns_server_do_query(struct dns_request *request, int skip_notify_event)
 		goto errout;
 	}
 
+#ifndef MINIMAL_BUILD
 	if (_dns_server_mdns_query_setup(request, server_group_name, &request_domain, domain_buffer,
 									 sizeof(domain_buffer)) != 0) {
 		goto errout;
 	}
+#endif
 
 	if (_dns_server_process_cname_pre(request) != 0) {
 		goto errout;
@@ -324,7 +334,9 @@ int _dns_server_do_query(struct dns_request *request, int skip_notify_event)
 
 	/* process cache */
 	if (request->prefetch == 0 && request->dualstack_selection_query == 0) {
+#ifndef MINIMAL_BUILD
 		_dns_server_mdns_query_setup_server_group(request, &server_group_name);
+#endif
 		if (_dns_server_process_cache(request) == 0) {
 			goto clean_exit;
 		}
@@ -341,7 +353,9 @@ int _dns_server_do_query(struct dns_request *request, int skip_notify_event)
 
 	// setup options
 	_dns_server_setup_query_option(request, &options);
+#ifndef MINIMAL_BUILD
 	_dns_server_mdns_query_setup_server_group(request, &server_group_name);
+#endif
 
 	pthread_mutex_lock(&server.request_list_lock);
 	if (list_empty(&server.request_list) && skip_notify_event == 1) {
@@ -575,6 +589,7 @@ static int _dns_server_process(struct dns_server_conn_head *conn, struct epoll_e
 			tlog(TLOG_DEBUG, "process TCP packet from %s failed.",
 				 get_host_by_addr(name, sizeof(name), (struct sockaddr *)&tcpclient->addr));
 		}
+#ifndef MINIMAL_BUILD
 	} else if (conn->type == DNS_CONN_TYPE_TLS_SERVER || conn->type == DNS_CONN_TYPE_HTTPS_SERVER) {
 		struct dns_server_conn_tls_server *tls_server = (struct dns_server_conn_tls_server *)conn;
 		ret = _dns_server_tls_accept(tls_server, event, now);
@@ -587,6 +602,7 @@ static int _dns_server_process(struct dns_server_conn_head *conn, struct epoll_e
 			tlog(TLOG_DEBUG, "process TLS packet from %s failed.",
 				 get_host_by_addr(name, sizeof(name), (struct sockaddr *)&tls_client->tcp.addr));
 		}
+#endif
 	} else {
 		tlog(TLOG_ERROR, "unsupported dns server type %d", conn->type);
 		_dns_server_client_close(conn);
@@ -620,6 +636,7 @@ static int _dns_server_socket(void)
 				goto errout;
 			}
 			break;
+#ifndef MINIMAL_BUILD
 		case DNS_BIND_TYPE_HTTPS:
 			if (_dns_server_socket_tls(bind_ip, DNS_CONN_TYPE_HTTPS_SERVER) != 0) {
 				goto errout;
@@ -635,6 +652,7 @@ static int _dns_server_socket(void)
 				goto errout;
 			}
 			break;
+#endif
 		default:
 			break;
 		}

--- a/src/dns_server/dns_server.h
+++ b/src/dns_server/dns_server.h
@@ -26,11 +26,21 @@
 #include "smartdns/dns.h"
 #include "smartdns/dns_conf.h"
 #include "smartdns/dns_server.h"
+#ifndef MINIMAL_BUILD
 #include "smartdns/http2.h"
+#endif
 #include "smartdns/tlog.h"
 #include "smartdns/util.h"
 
+#ifndef MINIMAL_BUILD
 #include <openssl/ssl.h>
+#else
+struct ssl_st;
+struct ssl_ctx_st;
+typedef struct ssl_st SSL;
+typedef struct ssl_ctx_st SSL_CTX;
+#include <stdio.h>
+#endif
 #include <pthread.h>
 
 #ifdef __cplusplus

--- a/src/dns_server/request.c
+++ b/src/dns_server/request.c
@@ -24,7 +24,9 @@
 #include "dns64.h"
 #include "dns_server.h"
 #include "dualstack.h"
+#ifndef MINIMAL_BUILD
 #include "mdns.h"
+#endif
 #include "neighbor.h"
 #include "ptr.h"
 #include "request_pending.h"
@@ -76,7 +78,9 @@ static int _dns_server_request_complete_with_all_IPs(struct dns_request *request
 		goto out;
 	}
 
+#ifndef MINIMAL_BUILD
 	_dns_server_need_append_mdns_local_cname(request);
+#endif
 
 	if (request->has_soa) {
 		tlog(TLOG_INFO, "result: %s, qtype: %d, SOA", request->domain, request->qtype);
@@ -202,7 +206,9 @@ static void _dns_server_complete_with_multi_ipaddress(struct dns_request *reques
 		return;
 	}
 
+#ifndef MINIMAL_BUILD
 	_dns_server_need_append_mdns_local_cname(request);
+#endif
 
 	_dns_server_post_context_init(&context, request);
 	context.do_cache = 1;

--- a/src/dns_server/server_tcp.c
+++ b/src/dns_server/server_tcp.c
@@ -21,11 +21,13 @@
 #include "server_tcp.h"
 #include "connection.h"
 #include "dns_server.h"
-#include "server_https.h"
 #include "server_socket.h"
-#include "server_tls.h"
 
+#ifndef MINIMAL_BUILD
+#include "server_https.h"
+#include "server_tls.h"
 #include "smartdns/http_parse.h"
+#endif
 
 #include <errno.h>
 #include <netinet/tcp.h>
@@ -153,6 +155,7 @@ int _dns_server_tcp_socket_send(struct dns_server_conn_tcp_client *tcp_client, v
 {
 	if (tcp_client->head.type == DNS_CONN_TYPE_TCP_CLIENT || tcp_client->head.type == DNS_CONN_TYPE_HTTP_CLIENT) {
 		return send(tcp_client->head.fd, data, data_len, MSG_NOSIGNAL);
+#ifndef MINIMAL_BUILD
 	} else if (tcp_client->head.type == DNS_CONN_TYPE_TLS_CLIENT ||
 			   tcp_client->head.type == DNS_CONN_TYPE_HTTPS_CLIENT) {
 		struct dns_server_conn_tls_client *tls_client = (struct dns_server_conn_tls_client *)tcp_client;
@@ -164,6 +167,7 @@ int _dns_server_tcp_socket_send(struct dns_server_conn_tcp_client *tcp_client, v
 			}
 		}
 		return ret;
+#endif
 	} else {
 		return -1;
 	}
@@ -173,6 +177,7 @@ int _dns_server_tcp_socket_recv(struct dns_server_conn_tcp_client *tcp_client, v
 {
 	if (tcp_client->head.type == DNS_CONN_TYPE_TCP_CLIENT || tcp_client->head.type == DNS_CONN_TYPE_HTTP_CLIENT) {
 		return recv(tcp_client->head.fd, data, data_len, MSG_NOSIGNAL);
+#ifndef MINIMAL_BUILD
 	} else if (tcp_client->head.type == DNS_CONN_TYPE_TLS_CLIENT ||
 			   tcp_client->head.type == DNS_CONN_TYPE_HTTPS_CLIENT) {
 		struct dns_server_conn_tls_client *tls_client = (struct dns_server_conn_tls_client *)tcp_client;
@@ -185,6 +190,7 @@ int _dns_server_tcp_socket_recv(struct dns_server_conn_tcp_client *tcp_client, v
 		}
 
 		return ret;
+#endif
 	} else {
 		return -1;
 	}
@@ -238,8 +244,10 @@ static int _dns_server_tcp_process_one_request(struct dns_server_conn_tcp_client
 	int proceed_len = 0;
 	unsigned char *request_data = NULL;
 	int ret = RECV_ERROR_FAIL;
+#ifndef MINIMAL_BUILD
 	int len = 0;
 	struct http_head *http_head = NULL;
+#endif
 	uint8_t *http_decode_data = NULL;
 	char *base64_query = NULL;
 
@@ -252,6 +260,7 @@ static int _dns_server_tcp_process_one_request(struct dns_server_conn_tcp_client
 			goto out;
 		}
 
+#ifndef MINIMAL_BUILD
 		if (tcpclient->head.type == DNS_CONN_TYPE_HTTPS_CLIENT || tcpclient->head.type == DNS_CONN_TYPE_HTTP_CLIENT) {
 			if ((total_len - proceed_len) <= 0) {
 				ret = RECV_ERROR_AGAIN;
@@ -342,7 +351,9 @@ static int _dns_server_tcp_process_one_request(struct dns_server_conn_tcp_client
 			}
 
 			proceed_len += len;
-		} else {
+		} else
+#endif
+		{
 			if ((total_len - proceed_len) <= (int)sizeof(unsigned short)) {
 				ret = RECV_ERROR_AGAIN;
 				goto out;
@@ -375,10 +386,12 @@ static int _dns_server_tcp_process_one_request(struct dns_server_conn_tcp_client
 			goto errout;
 		}
 
+#ifndef MINIMAL_BUILD
 		if (http_head != NULL) {
 			http_head_destroy(http_head);
 			http_head = NULL;
 		}
+#endif
 	}
 
 out:
@@ -389,9 +402,11 @@ out:
 	tcpclient->recvbuff.size -= proceed_len;
 
 errout:
+#ifndef MINIMAL_BUILD
 	if (http_head) {
 		http_head_destroy(http_head);
 	}
+#endif
 
 	if (http_decode_data) {
 		free(http_decode_data);
@@ -401,6 +416,7 @@ errout:
 		free(base64_query);
 	}
 
+#ifndef MINIMAL_BUILD
 	if (tcpclient->head.type == DNS_CONN_TYPE_HTTPS_CLIENT || tcpclient->head.type == DNS_CONN_TYPE_HTTP_CLIENT) {
 		if (ret == RECV_ERROR_BAD_PATH) {
 			_dns_server_reply_http_error(tcpclient, 404, "Not Found", "Not Found");
@@ -408,6 +424,7 @@ errout:
 			_dns_server_reply_http_error(tcpclient, 400, "Bad Request", "Bad Request");
 		}
 	}
+#endif
 
 	return ret;
 }

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -778,6 +778,7 @@ static proxy_handshake_state _proxy_handshake_socks5(struct proxy_conn *proxy_co
 	return PROXY_HANDSHAKE_ERR;
 }
 
+#ifndef MINIMAL_BUILD
 static int _proxy_handshake_http(struct proxy_conn *proxy_conn)
 {
 	int len = 0;
@@ -911,6 +912,7 @@ out:
 
 	return ret;
 }
+#endif
 
 proxy_handshake_state proxy_conn_handshake(struct proxy_conn *proxy_conn)
 {
@@ -926,7 +928,11 @@ proxy_handshake_state proxy_conn_handshake(struct proxy_conn *proxy_conn)
 	case PROXY_SOCKS5:
 		return _proxy_handshake_socks5(proxy_conn);
 	case PROXY_HTTP:
+#ifndef MINIMAL_BUILD
 		return _proxy_handshake_http(proxy_conn);
+#else
+		return PROXY_HANDSHAKE_ERR;
+#endif
 	default:
 		return PROXY_HANDSHAKE_ERR;
 	}

--- a/src/smartdns.c
+++ b/src/smartdns.c
@@ -32,8 +32,11 @@
 #include <fcntl.h>
 #include <getopt.h>
 #include <libgen.h>
+#include <linux/limits.h>
+#ifndef MINIMAL_BUILD
 #include <openssl/err.h>
 #include <openssl/ssl.h>
+#endif
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -194,6 +197,7 @@ static int _smartdns_prepare_server_flags(struct client_dns_server_flags *flags,
 		struct client_dns_server_flag_udp *flag_udp = &flags->udp;
 		flag_udp->ttl = server->ttl;
 	} break;
+#ifndef MINIMAL_BUILD
 	case DNS_SERVER_HTTP3:
 	case DNS_SERVER_HTTPS: {
 		struct client_dns_server_flag_https *flag_http = &flags->https;
@@ -228,6 +232,7 @@ static int _smartdns_prepare_server_flags(struct client_dns_server_flags *flags,
 		safe_strncpy(flag_tls->alpn, server->alpn, DNS_MAX_ALPN_LEN);
 		flag_tls->skip_check_cert = server->skip_check_cert;
 	} break;
+#endif
 	case DNS_SERVER_TCP:
 		break;
 	default:
@@ -373,6 +378,7 @@ static int _smartdns_plugin_exit(void)
 	return 0;
 }
 
+#ifndef MINIMAL_BUILD
 static int _smartdns_create_cert(void)
 {
 	uid_t uid = 0;
@@ -489,7 +495,9 @@ int smartdns_get_cert(char *key, char *cert)
 
 	return 0;
 }
+#endif /* MINIMAL_BUILD */
 
+#ifndef MINIMAL_BUILD
 static int _smartdns_init_ssl(void)
 {
 #if OPENSSL_API_COMPAT < 0x10100000L
@@ -510,6 +518,7 @@ static int _smartdns_destroy_ssl(void)
 #endif
 	return 0;
 }
+#endif
 
 static const char *_smartdns_log_path(void)
 {
@@ -671,10 +680,12 @@ static int _smartdns_init(void)
 		goto errout;
 	}
 
+#ifndef MINIMAL_BUILD
 	if (_smartdns_init_ssl() != 0) {
 		tlog(TLOG_ERROR, "init ssl failed.");
 		goto errout;
 	}
+#endif
 
 	if (_smartdns_init_load_from_resolv() != 0) {
 		tlog(TLOG_ERROR, "no dns server found, exit...");
@@ -748,7 +759,9 @@ static void _smartdns_exit(void)
 	dns_server_exit();
 	proxy_exit();
 	dns_stats_exit();
+#ifndef MINIMAL_BUILD
 	_smartdns_destroy_ssl();
+#endif
 	dns_timer_destroy();
 	tlog_exit();
 	dns_server_load_exit();
@@ -903,10 +916,12 @@ static int _smartdns_init_pre(void)
 
 	_set_rlimit();
 
+#ifndef MINIMAL_BUILD
 	if (_smartdns_create_cert() != 0) {
 		tlog(TLOG_ERROR, "create cert failed.");
 		return -1;
 	}
+#endif
 
 	return 0;
 }
@@ -1193,6 +1208,7 @@ int smartdns_main(int argc, char *argv[])
 			return dns_cache_print(optarg);
 			break;
 		case 257:
+#ifndef MINIMAL_BUILD
 			if (dns_is_quic_supported() == 0) {
 				fprintf(stdout, "quic is not supported.\n");
 				return 1;
@@ -1202,6 +1218,11 @@ int smartdns_main(int argc, char *argv[])
 			}
 			return 0;
 			break;
+#else
+			fprintf(stdout, "quic is not supported in minimal build.\n");
+			return 1;
+			break;
+#endif
 		default:
 			fprintf(stderr, "unknown option, please run %s -h for help.\n", argv[0]);
 			return 1;


### PR DESCRIPTION
Add MINIMAL=1 compile option that strips TLS/HTTPS/QUIC/HTTP3/mDNS support, producing a smaller binary without OpenSSL dependency.

Changes:
- Makefile: filter out TLS/HTTP/mDNS source files, skip -lssl -lcrypto
- Config parser: reject server-tls/server-https/server-quic/server-http3 and bind-tls/bind-https/bind-http directives
- Client dispatch: conditionally compile non-UDP/TCP branches
- Server dispatch: conditionally compile non-UDP/TCP connection types
- Forward-declare OpenSSL types (SSL, SSL_CTX, etc.) to avoid includes
- Guard SSL init/cert generation/proxy HTTP CONNECT under #ifndef
- Suppress unused-variable warnings in minimal build