### PR TITLE
fix global config `serve-expired no` not work

### DIFF
--- a/src/dns_server/cache.c
+++ b/src/dns_server/cache.c
@@ -395,7 +395,8 @@ int _dns_server_process_cache(struct dns_request *request)
 	}
 
 reply_cache:
-	if (dns_cache_get_ttl(dns_cache) <= 0 && request->no_serve_expired == 1) {
+	if (dns_cache_get_ttl(dns_cache) <= 0 &&
+		(request->no_serve_expired == 1 || request->conf->dns_serve_expired == 0)) {
 		goto out;
 	}
 

--- a/src/dns_server/rules.c
+++ b/src/dns_server/rules.c
@@ -451,7 +451,7 @@ int _dns_server_get_reply_ttl(struct dns_request *request, int ttl)
 
 	if ((request->passthrough == 0 || request->passthrough == 2) && dns_conf.cachesize > 0 &&
 		request->check_order_list->orders[0].type != DOMAIN_CHECK_NONE && request->no_serve_expired == 0 &&
-		request->has_soa == 0 && request->no_cache == 0) {
+		request->conf->dns_serve_expired == 1 && request->has_soa == 0 && request->no_cache == 0) {
 		reply_ttl = request->conf->dns_serve_expired_reply_ttl;
 		if (reply_ttl < 2) {
 			reply_ttl = 2;


### PR DESCRIPTION
代码在查询时仅检查了 bind -no-serve-expired 和 domain-rules -no-serve-expired。全局配置 serve-expired no 不起作用。本提交在查询后写入缓存前检查全局配置，如果配置了 serve-expired no 则与 -no-serve-expired 同等操作。