### PR TITLE
Fix serve_expired configuration logic in smartdns

### DIFF
--- a/package/openwrt/files/etc/init.d/smartdns
+++ b/package/openwrt/files/etc/init.d/smartdns
@@ -702,11 +702,11 @@ load_service()
 	config_get prefetch_domain "$section" "prefetch_domain" "0"
 	[ "$prefetch_domain" = "1" ] && conf_append "prefetch-domain" "yes"
 
-	config_get serve_expired "$section" "serve_expired" "0"
-	if [ "$serve_expired" = "1" ]; then
-		conf_append "serve-expired" "yes"
-	else
+	config_get serve_expired "$section" "serve_expired" "1"
+	if [ "$serve_expired" = "0" ]; then
 		conf_append "serve-expired" "no"
+	else
+		conf_append "serve-expired" "yes"
 	fi
 
 	config_get cache_size "$section" "cache_size" ""


### PR DESCRIPTION
当serve-expired no实际过期缓存功能配置不会被生成！
