### PR TITLE
build: 修复 musl 动态加载器软链接缺失

### DIFF
--- a/package/build-pkg.sh
+++ b/package/build-pkg.sh
@@ -159,7 +159,7 @@ copy_linker()
 	LINK_PATH=`$CC -print-file-name=$LINKER_NAME`
 	if [ "${LINK_PATH#/}" = "$LINK_PATH" ]; then
 		# LINK_PATH is not absolute, fallback to find it in the toolchain directory
-		local TC_DIR=$(dirname $(dirname $CC))
+		local TC_DIR=$(readlink -f "$(dirname "$(dirname "$CC")")")
 		echo "LINKER_NAME not found by print-file-name. Searching in $TC_DIR..."
 		local FOUND_PATH=$(find "$TC_DIR" -name "$LINKER_NAME" -print -quit 2>/dev/null)
 		if [ -n "$FOUND_PATH" ]; then
@@ -171,13 +171,14 @@ copy_linker()
 		fi
 	fi
 
-	SYM_LINKER_NAME=`readlink -f $LINK_PATH`
+	SYM_LINKER_NAME=`readlink -f "$LINK_PATH"`
+	LIBC_REAL_PATH=`readlink -f "$LIBC_PATH"`
 
 	echo "linker: $LINK_PATH"
 	echo "sym linker: $SYM_LINKER_NAME"
 	echo "libc: $LIBC_PATH"
 
-	if [ "$SYM_LINKER_NAME" = "$LIBC_PATH" ]; then
+	if [ "$SYM_LINKER_NAME" = "$LIBC_REAL_PATH" ]; then
 		ln -f -s $(basename $LIBC_PATH) $SMARTDNS_STATIC_DIR/lib/$(basename $LINKER_NAME)
 	else
 		cp $LINK_PATH $SMARTDNS_STATIC_DIR/lib -af

--- a/package/build-pkg.sh
+++ b/package/build-pkg.sh
@@ -199,6 +199,10 @@ copy_linker()
 		echo "copy ld-linux symlink failed"
 		return 1
 	fi
+	if [ ! -e "${SMARTDNS_STATIC_DIR}/lib/ld-linux.so" ]; then
+		echo "dynamic linker chain is broken: ${SMARTDNS_STATIC_DIR}/lib/ld-linux.so"
+		return 1
+	fi
 
 	return 0
 }


### PR DESCRIPTION
Fixes #2431

GitHub Actions 使用软链接形式的交叉编译工具链，导致打包脚本无法找到实际的 musl 动态加载器，最终生成了悬空的 `ld-linux.so`。

本次修改：

- 解析工具链目录和 libc 的真实路径。
- 确保生成完整链接：
  `ld-linux.so -> ld-musl-<arch>.so.1 -> libc.so`
- 打包时检查链接是否有效，避免再次生成悬空链接。

验证结果：

- [GitHub Actions 构建成功](https://github.com/Zesuy/smartdns/actions/runs/30292877155)
- 已检查 x86_64、x86、ARM 和 AArch64 的 IPK/APK，链接均完整。
- 在 OpenWrt 23.05.5 x86_64 上实际升级成功：

  ```text
  smartdns 1.2026.07.27-1824 (15f0602)
  ```