### PR TITLE
纠正 force-qtype-SOA 和 -force-https-soa 的阻止状态记录问题

### DIFF
--- a/src/dns_server/request.c
+++ b/src/dns_server/request.c
@@ -419,6 +419,10 @@ int dns_server_request_is_blocked(struct dns_request *request)
 		return 0;
 	}
 
+	if (request->force_soa) {
+		return 1;
+	}
+
 	if (request->qtype == DNS_T_HTTPS || request->qtype == DNS_T_SVCB) {
 		uint32_t flags = _dns_server_get_rule_flags(request);
 		if (flags & DOMAIN_FLAG_ADDR_HTTPS_SOA) {

--- a/src/dns_server/soa.c
+++ b/src/dns_server/soa.c
@@ -112,6 +112,7 @@ int _dns_server_reply_SOA_ext(int rcode, struct dns_request *request)
 		request->ip_ttl = DNS_SERVER_SOA_TTL;
 	}
 	request->has_soa = 1;
+	request->force_soa = 1;
 
 	struct dns_server_post_context context;
 	_dns_server_post_context_init(&context, request);
@@ -143,6 +144,7 @@ int _dns_server_qtype_soa(struct dns_request *request)
 		}
 	}
 
+	stats_inc(&dns_stats.request.blocked_count);
 	_dns_server_reply_SOA(DNS_RC_NOERROR, request);
 	tlog(TLOG_DEBUG, "force qtype %d soa", request->qtype);
 	return 0;


### PR DESCRIPTION
在配置了全局 force-qtype-SOA 或 bind.....-force-xxxx-soa时，查询在 UI 中被记录为"未阻止"，但实际上查询已经返回SOA。

本提交在 _dns_server_reply_SOA_ext() 中统一设置 request->force_soa = 1，使所有主动返回SOA的情形均记录force_soa = 1；在 UI调用的 dns_server_request_is_blocked() 中增加 request->force_soa 检查，使其正确显示阻止状态。

fix #2439