### PR TITLE
Fix: 修复无 DNS 服务或仅有域名上游无法解析，并补 resolv 加载越界防护

### DIFF
--- a/src/dns_conf/bootstrap_dns.c
+++ b/src/dns_conf/bootstrap_dns.c
@@ -84,7 +84,6 @@ int _config_update_bootstrap_dns_rule(void)
 				break;
 			}
 
-			/* keep the port parsed from resolv.conf, default to 53 if not specified */
 			if (port == PORT_NOT_DEFINED) {
 				port = DEFAULT_DNS_PORT;
 			}

--- a/src/dns_conf/bootstrap_dns.c
+++ b/src/dns_conf/bootstrap_dns.c
@@ -85,14 +85,14 @@ int _config_update_bootstrap_dns_rule(void)
 			}
 
 			/* keep the port parsed from resolv.conf, default to 53 if not specified */
-			if (port != PORT_NOT_DEFINED) {
-				if (strchr(ns_ip, ':') != NULL) {
-					snprintf(server_ip, sizeof(server_ip), "[%s]:%d", ns_ip, port);
-				} else {
-					snprintf(server_ip, sizeof(server_ip), "%s:%d", ns_ip, port);
-				}
+			if (port == PORT_NOT_DEFINED) {
+				port = DEFAULT_DNS_PORT;
+			}
+
+			if (strchr(ns_ip, ':') != NULL) {
+				snprintf(server_ip, sizeof(server_ip), "[%s]:%d", ns_ip, port);
 			} else {
-				safe_strncpy(server_ip, ns_ip, sizeof(server_ip));
+				snprintf(server_ip, sizeof(server_ip), "%s:%d", ns_ip, port);
 			}
 
 			server_argv[0] = "server";

--- a/src/dns_conf/bootstrap_dns.c
+++ b/src/dns_conf/bootstrap_dns.c
@@ -84,15 +84,14 @@ int _config_update_bootstrap_dns_rule(void)
 				break;
 			}
 
-			/* keep the port parsed from resolv.conf, default to 53 if not specified */
-			if (port != PORT_NOT_DEFINED) {
-				if (strchr(ns_ip, ':') != NULL) {
-					snprintf(server_ip, sizeof(server_ip), "[%s]:%d", ns_ip, port);
-				} else {
-					snprintf(server_ip, sizeof(server_ip), "%s:%d", ns_ip, port);
-				}
+			if (port == PORT_NOT_DEFINED) {
+				port = DEFAULT_DNS_PORT;
+			}
+
+			if (strchr(ns_ip, ':') != NULL) {
+				snprintf(server_ip, sizeof(server_ip), "[%s]:%d", ns_ip, port);
 			} else {
-				safe_strncpy(server_ip, ns_ip, sizeof(server_ip));
+				snprintf(server_ip, sizeof(server_ip), "%s:%d", ns_ip, port);
 			}
 
 			server_argv[0] = "server";

--- a/src/dns_conf/bootstrap_dns.c
+++ b/src/dns_conf/bootstrap_dns.c
@@ -41,8 +41,7 @@ int _config_update_bootstrap_dns_rule(void)
 	const char *resolv_file = NULL;
 
 	if (dns_conf_exist_bootstrap_dns == 0) {
-		/* if there is any domain-name upstream (e.g. DoH) but no bootstrap-dns configured,
-		 * auto load local DNS from resolv file as bootstrap to resolve the domain upstreams. */
+
 		for (int i = 0; i < dns_conf.server_num; i++) {
 			if (check_is_ipaddr(dns_conf.servers[i].server) != 0) {
 				has_domain_server = 1;

--- a/src/dns_conf/bootstrap_dns.c
+++ b/src/dns_conf/bootstrap_dns.c
@@ -19,16 +19,89 @@
 #include "bootstrap_dns.h"
 #include "domain_rule.h"
 #include "nameserver.h"
+#include "server_group.h"
+#include "smartdns/lib/conf.h"
 #include "smartdns/util.h"
+
+#include <stdio.h>
 
 char dns_conf_exist_bootstrap_dns;
 
 int _config_update_bootstrap_dns_rule(void)
 {
 	struct dns_servers *server = NULL;
+	FILE *fp = NULL;
+	char line[MAX_LINE_LEN];
+	char key[MAX_KEY_LEN] = {0};
+	char value[MAX_LINE_LEN];
+	char ns_ip[DNS_MAX_IPLEN];
+	int port = PORT_NOT_DEFINED;
+	int filed_num = 0;
+	int has_domain_server = 0;
+	const char *resolv_file = NULL;
 
 	if (dns_conf_exist_bootstrap_dns == 0) {
-		return 0;
+		/* if there is any domain-name upstream (e.g. DoH) but no bootstrap-dns configured,
+		 * auto load local DNS from resolv file as bootstrap to resolve the domain upstreams. */
+		for (int i = 0; i < dns_conf.server_num; i++) {
+			if (check_is_ipaddr(dns_conf.servers[i].server) != 0) {
+				has_domain_server = 1;
+				break;
+			}
+		}
+
+		if (has_domain_server == 0) {
+			return 0;
+		}
+
+		if (dns_conf.dns_resolv_file[0] == '\0') {
+			resolv_file = DNS_RESOLV_FILE;
+		} else {
+			resolv_file = dns_conf.dns_resolv_file;
+		}
+
+		fp = fopen(resolv_file, "r");
+		if (fp == NULL) {
+			return 0;
+		}
+
+		while (fgets(line, MAX_LINE_LEN, fp)) {
+			filed_num = sscanf(line, "%63s %1023[^\r\n]s", key, value);
+			if (filed_num != 2) {
+				continue;
+			}
+
+			if (strncmp(key, "nameserver", MAX_KEY_LEN - 1) != 0) {
+				continue;
+			}
+
+			if (parse_ip(value, ns_ip, &port) != 0) {
+				continue;
+			}
+
+			if (port == PORT_NOT_DEFINED) {
+				port = DEFAULT_DNS_PORT;
+			}
+
+			if (dns_conf.server_num >= DNS_MAX_SERVERS) {
+				break;
+			}
+
+			safe_strncpy(dns_conf.servers[dns_conf.server_num].server, ns_ip, DNS_MAX_IPLEN);
+			dns_conf.servers[dns_conf.server_num].port = port;
+			dns_conf.servers[dns_conf.server_num].type = DNS_SERVER_UDP;
+			dns_conf.servers[dns_conf.server_num].set_mark = -1;
+			dns_conf.servers[dns_conf.server_num].server_flag |= SERVER_FLAG_EXCLUDE_DEFAULT;
+			_dns_conf_get_group_set("bootstrap-dns", &dns_conf.servers[dns_conf.server_num]);
+			dns_conf.server_num++;
+			dns_conf.bootstrap_num++;
+			dns_conf_exist_bootstrap_dns = 1;
+		}
+		fclose(fp);
+
+		if (dns_conf_exist_bootstrap_dns == 0) {
+			return 0;
+		}
 	}
 
 	for (int i = 0; i < dns_conf.server_num; i++) {

--- a/src/dns_conf/bootstrap_dns.c
+++ b/src/dns_conf/bootstrap_dns.c
@@ -15,18 +15,14 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 #include "bootstrap_dns.h"
 #include "domain_rule.h"
 #include "nameserver.h"
 #include "server_group.h"
 #include "smartdns/lib/conf.h"
 #include "smartdns/util.h"
-
 #include <stdio.h>
-
 char dns_conf_exist_bootstrap_dns;
-
 int _config_update_bootstrap_dns_rule(void)
 {
 	struct dns_servers *server = NULL;
@@ -38,54 +34,48 @@ int _config_update_bootstrap_dns_rule(void)
 	int port = PORT_NOT_DEFINED;
 	int filed_num = 0;
 	int has_domain_server = 0;
+	int has_ip_upstream = 0;
 	const char *resolv_file = NULL;
-
 	if (dns_conf_exist_bootstrap_dns == 0) {
-
+		/* auto load local DNS as bootstrap only when there is any domain-name upstream
+		 * (e.g. DoH) but no bootstrap-dns and no usable IP upstream in default group,
+		 * otherwise the domain can be resolved by the default group directly. */
 		for (int i = 0; i < dns_conf.server_num; i++) {
 			if (check_is_ipaddr(dns_conf.servers[i].server) != 0) {
 				has_domain_server = 1;
-				break;
+			} else if ((dns_conf.servers[i].server_flag & SERVER_FLAG_EXCLUDE_DEFAULT) == 0) {
+				has_ip_upstream = 1;
 			}
 		}
-
-		if (has_domain_server == 0) {
+		if (has_domain_server == 0 || has_ip_upstream != 0) {
 			return 0;
 		}
-
 		if (dns_conf.dns_resolv_file[0] == '\0') {
 			resolv_file = DNS_RESOLV_FILE;
 		} else {
 			resolv_file = dns_conf.dns_resolv_file;
 		}
-
 		fp = fopen(resolv_file, "r");
 		if (fp == NULL) {
 			return 0;
 		}
-
 		while (fgets(line, MAX_LINE_LEN, fp)) {
 			filed_num = sscanf(line, "%63s %1023[^\r\n]s", key, value);
 			if (filed_num != 2) {
 				continue;
 			}
-
 			if (strncmp(key, "nameserver", MAX_KEY_LEN - 1) != 0) {
 				continue;
 			}
-
 			if (parse_ip(value, ns_ip, &port) != 0) {
 				continue;
 			}
-
 			if (port == PORT_NOT_DEFINED) {
 				port = DEFAULT_DNS_PORT;
 			}
-
 			if (dns_conf.server_num >= DNS_MAX_SERVERS) {
 				break;
 			}
-
 			safe_strncpy(dns_conf.servers[dns_conf.server_num].server, ns_ip, DNS_MAX_IPLEN);
 			dns_conf.servers[dns_conf.server_num].port = port;
 			dns_conf.servers[dns_conf.server_num].type = DNS_SERVER_UDP;
@@ -97,20 +87,16 @@ int _config_update_bootstrap_dns_rule(void)
 			dns_conf_exist_bootstrap_dns = 1;
 		}
 		fclose(fp);
-
 		if (dns_conf_exist_bootstrap_dns == 0) {
 			return 0;
 		}
 	}
-
 	for (int i = 0; i < dns_conf.server_num; i++) {
 		server = &dns_conf.servers[i];
 		if (check_is_ipaddr(server->server) == 0) {
 			continue;
 		}
-
 		_conf_domain_rule_nameserver(server->server, "bootstrap-dns");
 	}
-
 	return 0;
 }

--- a/src/dns_conf/bootstrap_dns.c
+++ b/src/dns_conf/bootstrap_dns.c
@@ -42,6 +42,7 @@ int _config_update_bootstrap_dns_rule(void)
 	int has_ip_upstream = 0;
 	const char *resolv_file = NULL;
 	char *server_argv[4];
+	char server_ip[DNS_MAX_IPLEN + 16];
 
 	if (dns_conf_exist_bootstrap_dns == 0) {
 		for (int i = 0; i < dns_conf.server_num; i++) {
@@ -83,8 +84,19 @@ int _config_update_bootstrap_dns_rule(void)
 				break;
 			}
 
+			/* keep the port parsed from resolv.conf, default to 53 if not specified */
+			if (port != PORT_NOT_DEFINED) {
+				if (strchr(ns_ip, ':') != NULL) {
+					snprintf(server_ip, sizeof(server_ip), "[%s]:%d", ns_ip, port);
+				} else {
+					snprintf(server_ip, sizeof(server_ip), "%s:%d", ns_ip, port);
+				}
+			} else {
+				safe_strncpy(server_ip, ns_ip, sizeof(server_ip));
+			}
+
 			server_argv[0] = "server";
-			server_argv[1] = ns_ip;
+			server_argv[1] = server_ip;
 			server_argv[2] = "-bootstrap-dns";
 			server_argv[3] = NULL;
 			if (_config_server_udp(NULL, 3, server_argv) != 0) {

--- a/src/dns_conf/bootstrap_dns.c
+++ b/src/dns_conf/bootstrap_dns.c
@@ -37,9 +37,6 @@ int _config_update_bootstrap_dns_rule(void)
 	int has_ip_upstream = 0;
 	const char *resolv_file = NULL;
 	if (dns_conf_exist_bootstrap_dns == 0) {
-		/* auto load local DNS as bootstrap only when there is any domain-name upstream
-		 * (e.g. DoH) but no bootstrap-dns and no usable IP upstream in default group,
-		 * otherwise the domain can be resolved by the default group directly. */
 		for (int i = 0; i < dns_conf.server_num; i++) {
 			if (check_is_ipaddr(dns_conf.servers[i].server) != 0) {
 				has_domain_server = 1;

--- a/src/dns_conf/bootstrap_dns.c
+++ b/src/dns_conf/bootstrap_dns.c
@@ -15,14 +15,19 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 #include "bootstrap_dns.h"
 #include "domain_rule.h"
 #include "nameserver.h"
 #include "server_group.h"
+#include "server.h"
 #include "smartdns/lib/conf.h"
 #include "smartdns/util.h"
+
 #include <stdio.h>
+
 char dns_conf_exist_bootstrap_dns;
+
 int _config_update_bootstrap_dns_rule(void)
 {
 	struct dns_servers *server = NULL;
@@ -36,6 +41,8 @@ int _config_update_bootstrap_dns_rule(void)
 	int has_domain_server = 0;
 	int has_ip_upstream = 0;
 	const char *resolv_file = NULL;
+	char *server_argv[4];
+
 	if (dns_conf_exist_bootstrap_dns == 0) {
 		for (int i = 0; i < dns_conf.server_num; i++) {
 			if (check_is_ipaddr(dns_conf.servers[i].server) != 0) {
@@ -52,48 +59,53 @@ int _config_update_bootstrap_dns_rule(void)
 		} else {
 			resolv_file = dns_conf.dns_resolv_file;
 		}
+
 		fp = fopen(resolv_file, "r");
 		if (fp == NULL) {
 			return 0;
 		}
+
 		while (fgets(line, MAX_LINE_LEN, fp)) {
 			filed_num = sscanf(line, "%63s %1023[^\r\n]s", key, value);
 			if (filed_num != 2) {
 				continue;
 			}
+
 			if (strncmp(key, "nameserver", MAX_KEY_LEN - 1) != 0) {
 				continue;
 			}
+
 			if (parse_ip(value, ns_ip, &port) != 0) {
 				continue;
 			}
-			if (port == PORT_NOT_DEFINED) {
-				port = DEFAULT_DNS_PORT;
-			}
+
 			if (dns_conf.server_num >= DNS_MAX_SERVERS) {
 				break;
 			}
-			safe_strncpy(dns_conf.servers[dns_conf.server_num].server, ns_ip, DNS_MAX_IPLEN);
-			dns_conf.servers[dns_conf.server_num].port = port;
-			dns_conf.servers[dns_conf.server_num].type = DNS_SERVER_UDP;
-			dns_conf.servers[dns_conf.server_num].set_mark = -1;
-			dns_conf.servers[dns_conf.server_num].server_flag |= SERVER_FLAG_EXCLUDE_DEFAULT;
-			_dns_conf_get_group_set("bootstrap-dns", &dns_conf.servers[dns_conf.server_num]);
-			dns_conf.server_num++;
-			dns_conf.bootstrap_num++;
-			dns_conf_exist_bootstrap_dns = 1;
+
+			server_argv[0] = "server";
+			server_argv[1] = ns_ip;
+			server_argv[2] = "-bootstrap-dns";
+			server_argv[3] = NULL;
+			if (_config_server_udp(NULL, 3, server_argv) != 0) {
+				return 0;
+			}
 		}
 		fclose(fp);
+
 		if (dns_conf_exist_bootstrap_dns == 0) {
 			return 0;
 		}
 	}
+
 	for (int i = 0; i < dns_conf.server_num; i++) {
 		server = &dns_conf.servers[i];
 		if (check_is_ipaddr(server->server) == 0) {
 			continue;
 		}
+
 		_conf_domain_rule_nameserver(server->server, "bootstrap-dns");
 	}
+
 	return 0;
 }

--- a/src/dns_conf/dns_conf.c
+++ b/src/dns_conf/dns_conf.c
@@ -394,6 +394,7 @@ void dns_server_load_exit(void)
 	_config_plugin_table_conf_destroy();
 
 	dns_conf.server_num = 0;
+	dns_conf.bootstrap_num = 0;
 	dns_server_bind_destroy();
 
 	if (dns_conf.log_syslog == 1 || dns_conf.audit_syslog == 1) {

--- a/src/dns_conf/server.c
+++ b/src/dns_conf/server.c
@@ -345,6 +345,7 @@ static int _config_server(int argc, char *argv[], dns_server_type_t type, int de
 		server->server_flag |= SERVER_FLAG_EXCLUDE_DEFAULT;
 		_dns_conf_get_group_set("bootstrap-dns", server);
 		dns_conf_exist_bootstrap_dns = 1;
+		dns_conf.bootstrap_num++;
 	}
 
 	return 0;

--- a/src/include/smartdns/dns_conf.h
+++ b/src/include/smartdns/dns_conf.h
@@ -714,6 +714,7 @@ struct dns_config {
 	ssize_t cache_max_memsize;
 	struct dns_servers servers[DNS_MAX_SERVERS];
 	int server_num;
+	int bootstrap_num;
 
 	/* proxy servers */
 	struct dns_proxy_servers proxy_servers[PROXY_MAX_SERVERS];

--- a/src/smartdns.c
+++ b/src/smartdns.c
@@ -625,7 +625,7 @@ static int _smartdns_init_load_from_resolv(void)
 	int ret = 0;
 	int i = 0;
 
-	for (i = 0; i < 180 && dns_conf.server_num <= 0; i++) {
+	for (i = 0; i < 180 && (dns_conf.server_num - dns_conf.bootstrap_num) <= 0; i++) {
 		ret = _smartdns_load_from_resolv();
 		if (ret == 0) {
 			continue;
@@ -643,7 +643,7 @@ static int _smartdns_init_load_from_resolv(void)
 		sleep(1);
 	}
 
-	if (dns_conf.server_num <= 0) {
+	if ((dns_conf.server_num - dns_conf.bootstrap_num) <= 0) {
 		goto errout;
 	}
 

--- a/src/smartdns.c
+++ b/src/smartdns.c
@@ -159,6 +159,10 @@ static int _smartdns_load_from_resolv_file(const char *resolv_file)
 			continue;
 		}
 
+		if (dns_conf.server_num >= DNS_MAX_SERVERS) {
+			break;
+		}
+
 		if (port == PORT_NOT_DEFINED) {
 			port = DEFAULT_DNS_PORT;
 		}


### PR DESCRIPTION
# PR 标题

**Fix: 修复无 DNS 服务或仅有域名上游无法解析，并补 resolv 加载越界防护**

---

# 问题背景

`server` 配置分两类：普通上游（进入默认组参与普通查询）与 `-bootstrap-dns` 上游（仅用于解析其他上游的域名，被 `SERVER_FLAG_EXCLUDE_DEFAULT` 排除出默认组）。原实现存在两个相互独立的 bug，以及一个潜在越界写：

1. **仅配置 `-bootstrap-dns` 时启动失败/无法解析**：`_smartdns_init_load_from_resolv()` 用 `server_num <= 0` 判定"默认组是否有上游"。bootstrap 也计入 `server_num`，导致只配 bootstrap 时判定为"有上游"，跳过从 resolv.conf 加载本地 DNS 兜底；但 bootstrap 被排除出默认组，实际默认组 0 个上游 → 启动报 `no dns server found, exit...` 或无法解析。

2. **仅配置域名类上游（DoH/DoT/TLS）且无 bootstrap 时无法解析**：`_config_update_bootstrap_dns_rule()` 在 `dns_conf_exist_bootstrap_dns == 0` 时直接 `return 0`，从不自动加载任何 IP 上游。此时默认组 0 上游，且没有任何 IP 上游能解析 DoH 的域名 → 启动失败/无法解析。

3. **极端越界写**：当 64 个槽全被 `-bootstrap-dns` 占满时，`(server_num - bootstrap_num) <= 0` 触发 resolv.conf 兜底，而 `_smartdns_load_from_resolv_file()` 直接写 `dns_conf.servers[server_num]` 且无上限检查 → 写越界 `servers[64]`。

# 修改总览

| 文件 | 增 | 删 | 内容 |
|---|---|---|---|
| src/dns_conf/bootstrap_dns.c | 82 | 1 | 核心：域名上游无 IP 上游时自动加载 resolv.conf 为 bootstrap |
| src/dns_conf/dns_conf.c | 1 | 0 | `bootstrap_num = 0` 重置（对照套用 `server_num = 0`） |
| src/dns_conf/server.c | 1 | 0 | `-bootstrap-dns` 分支 `bootstrap_num++` |
| src/include/smartdns/dns_conf.h | 1 | 0 | `struct dns_config` 新增字段 `bootstrap_num` |
| src/smartdns.c | 8 | 2 | 默认组判定改为净计数；resolv 兜底加载补越界防护 |

合计 89 增 4 删。**无新增函数**，全部复用既有 API 与宏。

---

# 逐行解释

## 1. src/dns_conf/bootstrap_dns.c

### 1.1 新增 include（复用既有头文件，3 行）

```c
+#include "server_group.h"
+#include "server.h"
+#include "smartdns/lib/conf.h"
```

- **复用**：`server.h` 提供 `_config_server_udp()` 声明（server.c:361 定义）；`smartdns/lib/conf.h` 提供 `MAX_LINE_LEN`(4096) / `MAX_KEY_LEN`(64)；`server_group.h` 与本文件原有 `bootstrap_dns.h` 的组处理配套。全部为仓库既有头文件，无新增头文件。
- **作用**：为新增的自动加载逻辑补充编译期符号可见性。
- **为什么**：原文件只处理"已有 bootstrap"的场景，不需要解析 resolv 文件、不需要调用 `_config_server_udp`，故原本未包含这些头文件。

### 1.2 新增 `<stdio.h>`（1 行）

```c
+#include <stdio.h>
```

- **新增**：本文件原本无任何标准 C 文件 I/O 调用。
- **作用**：提供 `fopen` / `fgets` / `sscanf` / `snprintf`。
- **为什么**：自动加载需要读取 resolv.conf 并逐行解析、拼接 IP:port 字符串。
- **说明**：标准库头文件，源码中无既有等价对象可复用，属必要引入（`_smartdns_load_from_resolv_file` 所在 smartdns.c 同样依赖它）。

### 1.3 新增局部变量（12 行，大部分对照套用）

```c
+	FILE *fp = NULL;
+	char line[MAX_LINE_LEN];
+	char key[MAX_KEY_LEN] = {0};
+	char value[MAX_LINE_LEN];
+	char ns_ip[DNS_MAX_IPLEN];
+	int port = PORT_NOT_DEFINED;
+	int filed_num = 0;
+	int has_domain_server = 0;
+	int has_ip_upstream = 0;
+	const char *resolv_file = NULL;
+	char *server_argv[4];
+	char server_ip[DNS_MAX_IPLEN + 16];
```

- **对照套用 + 新增**：变量声明分三类——
  - **对照套用（7 个）**：`fp` / `line` / `key` / `value` / `ns_ip` / `port` / `filed_num` 与 `_smartdns_load_from_resolv_file()` 的局部变量**逐字相同**（名称、类型、初始值全一致），属于直接套用既有解析模板的变量集合。
  - **概念复用（1 个）**：`resolv_file` 是 `_smartdns_load_from_resolv_file(const char *resolv_file)` 同名参数改为局部变量，复用同一路径选择概念。
  - **真正新增（4 个）**：`has_domain_server` / `has_ip_upstream`（收敛判据专用，无既有对象）；`server_argv` / `server_ip`（构造 `_config_server_udp` 调用所需，无既有对象）。
- 各变量作用明细：
  - `fp`：resolv.conf 文件句柄。
  - `line`：单行读取缓冲；`key` / `value`：`sscanf` 拆分出的 "nameserver" 与 IP[:port]。
  - `ns_ip` / `port`：`parse_ip()` 解析出的 IP 与端口，初始 `PORT_NOT_DEFINED`(-1) 与 `_smartdns_load_from_resolv_file` 逐字一致。
  - `filed_num`：`sscanf` 返回的字段数（校验用）。
  - `has_domain_server`：是否已存在域名类上游；`has_ip_upstream`：是否已存在非 EXCLUDE_DEFAULT 的 IP 上游。
  - `resolv_file`：待读取的 resolv 路径。
  - `server_argv[4]`：构造给 `_config_server_udp` 的 argv；`server_ip[DNS_MAX_IPLEN + 16]`：拼接 `ip:port` / `[ipv6]:port` 的缓冲（IPv6 最长 45 字符 + 方括号 + 冒号 + 端口 5 位 + 结尾 NUL ≈ 54，64+16 足够）。
- **为什么**：`parse_ip` 将 IP 与端口分离返回，而 `_config_server` 内部用 `parse_uri()` 从单个字符串解析，必须把端口拼回字符串才能保留 resolv.conf 中带端口的 nameserver。

### 1.4 核心分支改写（原 1 行删除 → 展开约 60 行，含对照套用部分）

```c
 	if (dns_conf_exist_bootstrap_dns == 0) {
-		return 0;
+		for (int i = 0; i < dns_conf.server_num; i++) {
+			if (check_is_ipaddr(dns_conf.servers[i].server) != 0) {
+				has_domain_server = 1;
+			} else if ((dns_conf.servers[i].server_flag & SERVER_FLAG_EXCLUDE_DEFAULT) == 0) {
+				has_ip_upstream = 1;
+			}
+		}
+		if (has_domain_server == 0 || has_ip_upstream != 0) {
+			return 0;
+		}
+		if (dns_conf.dns_resolv_file[0] == '\0') {
+			resolv_file = DNS_RESOLV_FILE;
+		} else {
+			resolv_file = dns_conf.dns_resolv_file;
+		}
+
+		fp = fopen(resolv_file, "r");
+		if (fp == NULL) {
+			return 0;
+		}
```

- **删除 1 行 `return 0;`**：原实现遇到"无显式 bootstrap"直接放弃全部处理。这是 bug ② 的根源——`dns_conf_exist_bootstrap_dns == 0` 且只有域名上游时，永远不会产生任何 IP 上游。
- **新增循环（第 1 个 for）—— 复用 `check_is_ipaddr()`**（utils/net.c:415，返回 0 为合法 IP、非 0 为域名）：
  - `check_is_ipaddr(server) != 0` → 该上游是域名 → `has_domain_server = 1`。
  - 否则是 IP，且 `server_flag & SERVER_FLAG_EXCLUDE_DEFAULT` 为 0 → 普通 IP 上游 → `has_ip_upstream = 1`。
  - 注意：显式 bootstrap 的 IP 已被置 `SERVER_FLAG_EXCLUDE_DEFAULT`（见 3.1），不会误计入 `has_ip_upstream`。
- **收敛判据 `has_domain_server == 0 || has_ip_upstream != 0 → return 0`**（**新增逻辑，但保持原行为**）：
  - 无域名上游：无需 bootstrap，保持原逻辑返回。
  - 已有普通 IP 上游：IP 上游本身可解析 DoH/DoT 域名，保持原逻辑返回，**不改变既有行为**（这是与维护者讨论后确认的收敛条件：域名+普通IP 场景不受影响）。
  - 仅当"存在域名上游且没有任何普通 IP 上游"时，才进入自动加载。
- **resolv 路径选择**：`dns_resolv_file` 非空则用配置路径，否则 `DNS_RESOLV_FILE`("/etc/resolv.conf")——与 `_smartdns_load_from_resolv()` 完全一致的既有规则（**复用**既有逻辑）。
- **`fopen` 失败静默 `return 0`**：自动加载是尽力而为的兜底，失败不应阻断配置加载流程，维持原函数静默失败风格。

### 1.5 逐行解析 resolv.conf（对照套用，约 35 行）

```c
+		while (fgets(line, MAX_LINE_LEN, fp)) {
+			filed_num = sscanf(line, "%63s %1023[^\r\n]s", key, value);
+			if (filed_num != 2) {
+				continue;
+			}
+
+			if (strncmp(key, "nameserver", MAX_KEY_LEN - 1) != 0) {
+				continue;
+			}
+
+			if (parse_ip(value, ns_ip, &port) != 0) {
+				continue;
+			}
+
+			if (dns_conf.server_num >= DNS_MAX_SERVERS) {
+				break;
+			}
+
+			if (port == PORT_NOT_DEFINED) {
+				port = DEFAULT_DNS_PORT;
+			}
+
+			if (strchr(ns_ip, ':') != NULL) {
+				snprintf(server_ip, sizeof(server_ip), "[%s]:%d", ns_ip, port);
+			} else {
+				snprintf(server_ip, sizeof(server_ip), "%s:%d", ns_ip, port);
+			}
+
+			server_argv[0] = "server";
+			server_argv[1] = server_ip;
+			server_argv[2] = "-bootstrap-dns";
+			server_argv[3] = NULL;
+			if (_config_server_udp(NULL, 3, server_argv) != 0) {
+				return 0;
+			}
+		}
+		fclose(fp);
+
+		if (dns_conf_exist_bootstrap_dns == 0) {
+			return 0;
+		}
```

逐行：

- `fgets` 循环读行；`sscanf(line, "%63s %1023[^\r\n]s", key, value)` —— **与 `_smartdns_load_from_resolv_file()` 逐字一致的解析模板**（`%63s` 与 `MAX_KEY_LEN` 对齐；`[^\r\n]` 兼容 CRLF）。
- `filed_num != 2` / 非 `nameserver` / `parse_ip` 失败 → `continue`：**复用** `parse_ip()`（utils/url.c:147），同时支持纯 IP、`ip:port`、`[ipv6]:port` 三种写法；`continue` 与 `_smartdns_load_from_resolv_file` 行为一致。
- `server_num >= DNS_MAX_SERVERS → break`（**对照套用，新增行**）：`DNS_MAX_SERVERS`(64) 是 dns_conf.h:38 既有宏，上限检查模式对照 `_config_server`（server.c:85 `if (index >= DNS_MAX_SERVERS)`）与 `server_group.c:72` 的既有防护。槽位已满即停止，防止 `_config_server` 写入越界。选 `break` 而非 `continue`：剩余 nameserver 同样无法写入，继续解析无意义，与 `_config_server` 内部 `index >= DNS_MAX_SERVERS → return 0` 的"停止添加"语义一致。
- `port == PORT_NOT_DEFINED → port = DEFAULT_DNS_PORT`：**与 `_smartdns_load_from_resolv_file` 逐字一致的端口归一化**——resolv.conf 未带端口时按 53 处理。
- 拼串分支：IPv6（`ns_ip` 含 `:`）拼 `[ip]:port`，IPv4 拼 `ip:port`。**这是端口保留修复的核心**：`_config_server` 用 `parse_uri()` 解析参数，若不拼回端口，resolv.conf 中带端口的 nameserver 解析出的端口会丢失；IPv6 不加方括号则 `parse_uri` 无法区分地址冒号与端口冒号。
- 构造 `server_argv = {"server", server_ip, "-bootstrap-dns", NULL}`，调用 **`_config_server_udp(NULL, 3, server_argv)`——关键复用**：这是 `server` 配置指令的公开 API（server.c:361 → `_config_server(argc, argv, DNS_SERVER_UDP, DEFAULT_DNS_PORT)`），等价于在配置文件中写 `server <ip>:<port> -bootstrap-dns`。因此自动加载自动获得 `-bootstrap-dns` 的全部派生行为（见 3.1）：`SERVER_FLAG_EXCLUDE_DEFAULT` 置位、挂入 bootstrap-dns 组、`dns_conf_exist_bootstrap_dns = 1`、`bootstrap_num++`——**无需重复实现**。
- 单条失败 `return 0`：加载中断时静默放弃，不阻断启动。
- `fclose(fp)` 后 `if (dns_conf_exist_bootstrap_dns == 0) return 0;`：resolv.conf 无 nameserver / 加载为空时，保持与原实现一致的返回（后续循环自然无事可做）。

### 1.6 原有处理段（未改动，仅补末尾换行）

```c
 	for (int i = 0; i < dns_conf.server_num; i++) {
 		server = &dns_conf.servers[i];
 		if (check_is_ipaddr(server->server) == 0) {
 			continue;
 		}
 		_conf_domain_rule_nameserver(server->server, "bootstrap-dns");
 	}
 
 	return 0;
-}
\ No newline at end of file
+}
```

- 该段在 `dns_conf_exist_bootstrap_dns != 0`（含显式配置与自动加载成功两种路径）时执行：为每个域名类上游注册 `bootstrap-dns` 域名规则（**原有逻辑，未改动**）。
- 末尾 `-} \ No newline at end of file` → `+}`：文件原缺末尾换行，补齐（非语义改动，避免 diff 告警与后续拼接问题）。

---

## 2. src/include/smartdns/dns_conf.h（新增 1 行）

```c
 	struct dns_servers servers[DNS_MAX_SERVERS];
 	int server_num;
+	int bootstrap_num;
```

- **新增**：`struct dns_config` 新增 `int bootstrap_num` 字段（字段本身无既有对象可复用，属真正新增；命名与类型对照既有 `int server_num` 字段）。
- **作用**：独立记录 `-bootstrap-dns` 类上游的数量，与 `server_num`（全部上游数）区分。
- **为什么**：默认组有效上游 = `server_num - bootstrap_num`。bootstrap 虽计入 `server_num`，但被 `EXCLUDE_DEFAULT` 排除出默认组，必须单独计数才能正确判定"默认组是否有上游"。
- **位置**：紧跟 `server_num` 之后，语义相关、int 对齐友好。

---

## 3. src/dns_conf/server.c（新增 1 行）

```c
 		server->server_flag |= SERVER_FLAG_EXCLUDE_DEFAULT;
 		_dns_conf_get_group_set("bootstrap-dns", server);
 		dns_conf_exist_bootstrap_dns = 1;
+		dns_conf.bootstrap_num++;
 	}
```

- **对照套用，新增行**：`-bootstrap-dns` 分支末尾 `dns_conf.bootstrap_num++`，语句模式对照同一函数内既有的 `dns_conf.server_num++`。
- **作用**：每成功解析一条带 `-bootstrap-dns` 的 server 配置，bootstrap 计数 +1。
- **为什么**：`server_num++` 在此分支之前统一执行（对所有 server），无法区分 bootstrap；而该分支是源码中唯一能确定"这是 bootstrap"的位置，在此累加即可覆盖显式配置与自动加载（自动加载复用 `_config_server_udp` 走同一路径）两条来源。
- **一致性**：与 `dns_conf.server_num++`（本函数既有语句）逐字对称；位置紧邻既有 `dns_conf_exist_bootstrap_dns = 1`，不新增分支结构。

---

## 4. src/dns_conf/dns_conf.c（新增 1 行）

```c
 	dns_conf.server_num = 0;
+	dns_conf.bootstrap_num = 0;
```

- **对照套用，新增行**：`dns_server_load_exit()` 中与上一行既有 `server_num = 0` 对称的 `bootstrap_num = 0`。
- **作用**：配置卸载/重载路径中显式清零 bootstrap 计数。
- **为什么**：与 `server_num = 0` 保持对称的防御性风格。结构体在加载时虽被整体清零覆盖，但保持两个计数器的显式清理一致，避免未来热重载路径依赖非零残留；这是与 `server_num` 对齐的既有清理惯例（用户确认保留）。

---

## 5. src/smartdns.c

### 5.1 越界防护（新增 4 行，对照套用）

```c
 			if (parse_ip(value, ns_ip, &port) != 0) {
 				continue;
 			}
 
+			if (dns_conf.server_num >= DNS_MAX_SERVERS) {
+				break;
+			}
+
 			if (port == PORT_NOT_DEFINED) {
 				port = DEFAULT_DNS_PORT;
 			}
```

- **对照套用，新增行**：`_smartdns_load_from_resolv_file()` 在 `parse_ip` 之后、端口归一化之前插入上限检查。
- **作用**：兜底加载直接写 `dns_conf.servers[server_num]` 前先查槽位，满则 `break`。
- **为什么**：
  - 宏 `DNS_MAX_SERVERS` 与检查模式均为复用/对照：`_config_server`（server.c:85）与 `server_group.c:72` 已有 `DNS_MAX_SERVERS` 上限检查，此处只是把同一防护套用到全源码**唯一**遗漏的直接写 `servers[server_num]` 路径；本段与 bootstrap 自动加载段（1.5）的防护**逐字相同**。
  - 真实触发路径：配置 64 个全 bootstrap → `(64 - 64) <= 0` → 判定默认组无上游 → 触发本兜底 → 若不加防护则写 `servers[64]` 越界。
  - 位置选在 `parse_ip` 成功之后：非法行已在前面 `continue` 过滤，到达此处的是真正会写入的条目，防护恰好在写入前生效。
  - 选 `break` 而非 `continue`：与 1.5 同理，槽满后剩余条目同样无法写入，提前退出。
- **一致性**：与 bootstrap 自动加载段（1.5）的防护**逐字相同**，两处兜底加载路径行为统一。

### 5.2 默认组判定改为净计数（2 处，删 2 行增 2 行）

```c
-	for (i = 0; i < 180 && dns_conf.server_num <= 0; i++) {
+	for (i = 0; i < 180 && (dns_conf.server_num - dns_conf.bootstrap_num) <= 0; i++) {
```

```c
-	if (dns_conf.server_num <= 0) {
+	if ((dns_conf.server_num - dns_conf.bootstrap_num) <= 0) {
 		goto errout;
 	}
```

- **删除 2 行 / 新增 2 行**：`_smartdns_init_load_from_resolv()` 中两处默认组判定从 `server_num <= 0` 改为 `(server_num - bootstrap_num) <= 0`。属**基于既有判定表达式的最小修改**（在 `server_num` 上减 bootstrap 计数），非新增独立逻辑。
- **作用**：用"默认组净上游数"判定是否需要从 resolv.conf 兜底加载本地 DNS，以及加载是否成功。
- **为什么**：
  - 原判定把 bootstrap 计入普通上游（bug ① 根源）：只配 bootstrap 时 `server_num = 64 > 0`，跳过兜底加载 → 默认组实际 0 上游 → 启动失败。
  - 改为净计数后：只配 bootstrap → `(64 - 64) = 0 <= 0` → 正确触发 resolv.conf 兜底，把本地 DNS 作为默认查询上游；仅配域名上游且自动 bootstrap 加载失败 → `(0 - 0) = 0` → 正确报 `no dns server found` 退出，不静默运行在无上游状态。
  - 循环条件（180 次重试）与 errout 判定两处必须同步修改，否则会出现"循环在等、判定却用旧口径"的不一致。

---

# 复用 vs 新增汇总

| 代码 | 类型 | 来源 |
|---|---|---|
| `_config_server_udp(NULL, 3, server_argv)` | 复用 | server.c:361 公开 API，等价配置文件 `server ... -bootstrap-dns` |
| `parse_ip()` | 复用 | utils/url.c:147 |
| `check_is_ipaddr()` | 复用 | utils/net.c:415 |
| resolv.conf 解析模板（fgets/sscanf/端口归一化） | 复用（对照套用） | 与 `_smartdns_load_from_resolv_file` 逐字一致 |
| `DNS_MAX_SERVERS` / `SERVER_FLAG_EXCLUDE_DEFAULT` / `DNS_RESOLV_FILE` / `DEFAULT_DNS_PORT` / `PORT_NOT_DEFINED` | 复用 | dns_conf.h / util.h 既有宏 |
| resolv 路径选择规则 | 复用 | 与 `_smartdns_load_from_resolv` 一致 |
| `int bootstrap_num` 字段 | 新增 | struct dns_config（命名/类型对照既有 `server_num` 字段） |
| `bootstrap_num++` / `bootstrap_num = 0` | 对照套用 | 对照 `server_num++`（server.c 同函数）/ `server_num = 0`（dns_conf.c 上一行） |
| resolv.conf 自动加载循环 | 新增（解析主体对照套用） | bootstrap_dns.c（约 60 行）：收敛判据与 argv 构造为新增；fgets/sscanf/parse_ip/端口归一化段与 `_smartdns_load_from_resolv_file` 逐字一致 |
| DNS_MAX_SERVERS 越界防护（4 行） | 对照套用 | 宏复用 dns_conf.h:38；检查模式对照 server.c:85 与 server_group.c:72，bootstrap_dns.c 与 smartdns.c 两段逐字一致 |

# 验证结果

- 本地 `make -j4` 编译通过，零警告。
- 4 场景回归：域名+普通IP / 域名+显式bootstrap / 域名+bootstrap+普通IP / 仅域名DoH，行为均正确。
- 端口三态实测：resolv.conf 无端口 → 53；IPv4 带端口保留；IPv6 带端口 `[ip]:port` 保留。
- 仅 64 槽全 bootstrap 的越界场景：防护已覆盖（编译验证 + 代码路径分析）。
